### PR TITLE
SherlockML auth implementation for requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .mypy_cache/
 .pytest_cache/
 __pycache__/
+*.pyc

--- a/sherlockml/clients/auth.py
+++ b/sherlockml/clients/auth.py
@@ -67,14 +67,18 @@ class SherlockMLAuth(AuthBase):
     >>> auth = SherlockMLAuth('https://hudson.example.sherlockml.net',
                               your_client_id, your_client_secret)
 
-    then pass it as the ``auth`` argument when constructing a ``requests``
-    session:
+    then pass it as the ``auth`` argument when making a request with
+    ``requests``:
+
+    >>> import requests
+    >>> requests.get('http://service.example.sherlockml.net', auth=auth)
+
+    You can also set it as the ``auth`` attribute on a
+    :class:`requests.Session`, so that subsequent requests will be
+    authenticated automatically:
 
     >>> import requests
     >>> session = requests.Session(auth=auth)
-
-    subsequent requests made using this session will be authenticated
-    automatically.
     """
 
     def __init__(self, auth_service_url, client_id, client_secret):

--- a/sherlockml/clients/auth.py
+++ b/sherlockml/clients/auth.py
@@ -17,6 +17,7 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 
 import requests
+from requests.auth import AuthBase
 import pytz
 
 
@@ -46,3 +47,39 @@ class AccessTokenClient(object):
         expires_at = now + timedelta(seconds=body['expires_in'])
 
         return AccessToken(token, expires_at)
+
+
+class SherlockMLAuth(AuthBase):
+    """Requests auth implementation for accessing SherlockML services.
+
+    Parameters
+    ----------
+    auth_service_url : str
+        The URL of the SherlockML authentication service
+    client_id : str
+        The SherlockML client ID to use for authentication
+    client_secret : str
+        The client secret associated with the client ID
+    """
+
+    def __init__(self, auth_service_url, client_id, client_secret):
+        self.auth_service_url = auth_service_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.access_token = None
+
+    def _get_token(self):
+        client = AccessTokenClient(self.auth_service_url)
+        return client.get_access_token(self.client_id, self.client_secret)
+
+    def __call__(self, request):
+
+        if self.access_token is None:
+            self.access_token = self._get_token()
+        if self.access_token.expires_at < datetime.now(tz=pytz.utc):
+            self.access_token = self._get_token()
+
+        header_content = 'Bearer {}'.format(self.access_token.token)
+        request.headers['Authorization'] = header_content
+
+        return request

--- a/sherlockml/clients/auth.py
+++ b/sherlockml/clients/auth.py
@@ -78,7 +78,8 @@ class SherlockMLAuth(AuthBase):
     authenticated automatically:
 
     >>> import requests
-    >>> session = requests.Session(auth=auth)
+    >>> session = requests.Session()
+    >>> session.auth = auth
     """
 
     def __init__(self, auth_service_url, client_id, client_secret):

--- a/sherlockml/clients/auth.py
+++ b/sherlockml/clients/auth.py
@@ -60,6 +60,21 @@ class SherlockMLAuth(AuthBase):
         The SherlockML client ID to use for authentication
     client_secret : str
         The client secret associated with the client ID
+
+    To perform an authenticated request against a SherlockML service, first
+    construct an instance of this class:
+
+    >>> auth = SherlockMLAuth('https://hudson.example.sherlockml.net',
+                              your_client_id, your_client_secret)
+
+    then pass it as the ``auth`` argument when constructing a ``requests``
+    session:
+
+    >>> import requests
+    >>> session = requests.Session(auth=auth)
+
+    subsequent requests made using this session will be authenticated
+    automatically.
     """
 
     def __init__(self, auth_service_url, client_id, client_secret):

--- a/sherlockml/clients/auth.py
+++ b/sherlockml/clients/auth.py
@@ -16,9 +16,9 @@
 from collections import namedtuple
 from datetime import datetime, timedelta
 
+import pytz
 import requests
 from requests.auth import AuthBase
-import pytz
 
 
 AccessToken = namedtuple('AccessToken', ['token', 'expires_at'])

--- a/tests/clients/test_auth.py
+++ b/tests/clients/test_auth.py
@@ -35,7 +35,7 @@ def mock_datetime_now(mocker):
     return datetime_mock
 
 
-def test_get_access_token(requests_mock, mock_datetime_now):
+def test_access_token_client(requests_mock, mock_datetime_now):
 
     requests_mock.post(
         '{}/access_token'.format(MOCK_HUDSON_URL),

--- a/tests/clients/test_auth.py
+++ b/tests/clients/test_auth.py
@@ -18,20 +18,22 @@ from datetime import datetime, timedelta
 import pytest
 import pytz
 
-from sherlockml.clients.auth import AccessTokenClient
+from sherlockml.clients.auth import (
+    AccessToken, AccessTokenClient, SherlockMLAuth
+)
 
 
 MOCK_HUDSON_URL = 'https://hudson.example.com'
 MOCK_CLIENT_ID = 'client-id'
 MOCK_CLIENT_SECRET = 'client-secret'
-MOCK_ACCESS_TOKEN = 'access-token'
-MOCK_NOW = datetime(2018, 1, 1, 10, 0, 0, tzinfo=pytz.utc)
+MOCK_ACCESS_TOKEN_MATERIAL = 'access-token'
+NOW = datetime.now(tz=pytz.utc)
 
 
 @pytest.fixture
 def mock_datetime_now(mocker):
     datetime_mock = mocker.patch('sherlockml.clients.auth.datetime')
-    datetime_mock.now.return_value = MOCK_NOW
+    datetime_mock.now.return_value = NOW
     return datetime_mock
 
 
@@ -39,7 +41,7 @@ def test_access_token_client(requests_mock, mock_datetime_now):
 
     requests_mock.post(
         '{}/access_token'.format(MOCK_HUDSON_URL),
-        json={'access_token': MOCK_ACCESS_TOKEN, 'expires_in': 600}
+        json={'access_token': MOCK_ACCESS_TOKEN_MATERIAL, 'expires_in': 600}
     )
 
     client = AccessTokenClient(MOCK_HUDSON_URL)
@@ -52,5 +54,52 @@ def test_access_token_client(requests_mock, mock_datetime_now):
         'client_secret': MOCK_CLIENT_SECRET,
         'grant_type': 'client_credentials'
     }
-    assert access_token.token == MOCK_ACCESS_TOKEN
-    assert access_token.expires_at == MOCK_NOW + timedelta(minutes=10)
+    assert access_token.token == MOCK_ACCESS_TOKEN_MATERIAL
+    assert access_token.expires_at == NOW + timedelta(minutes=10)
+
+
+@pytest.mark.parametrize('cached_token', [
+    None,
+    AccessToken('old-token', NOW - timedelta(minutes=10))
+])
+def test_sherlockml_auth(mocker, cached_token):
+
+    mock_client = mocker.Mock()
+    mock_client.get_access_token.return_value = AccessToken(
+        MOCK_ACCESS_TOKEN_MATERIAL,
+        NOW + timedelta(minutes=10)
+    )
+    client_patch = mocker.patch('sherlockml.clients.auth.AccessTokenClient',
+                                return_value=mock_client)
+
+    auth = SherlockMLAuth(MOCK_HUDSON_URL, MOCK_CLIENT_ID, MOCK_CLIENT_SECRET)
+
+    unauthenticated_request = mocker.Mock(headers={})
+    request = auth(unauthenticated_request)
+
+    assert request.headers['Authorization'] == 'Bearer access-token'
+    client_patch.assert_called_once_with(MOCK_HUDSON_URL)
+    mock_client.get_access_token.assert_called_once_with(
+        MOCK_CLIENT_ID,
+        MOCK_CLIENT_SECRET
+    )
+    assert auth.access_token is not None
+
+
+def test_sherlockml_auth_cached(mocker):
+
+    mock_client = mocker.Mock()
+    mocker.patch('sherlockml.clients.auth.AccessTokenClient',
+                 return_value=mock_client)
+
+    auth = SherlockMLAuth(MOCK_HUDSON_URL, MOCK_CLIENT_ID, MOCK_CLIENT_SECRET)
+    auth.access_token = AccessToken(
+        MOCK_ACCESS_TOKEN_MATERIAL,
+        NOW + timedelta(minutes=10)
+    )
+
+    unauthenticated_request = mocker.Mock(headers={})
+    request = auth(unauthenticated_request)
+
+    assert request.headers['Authorization'] == 'Bearer access-token'
+    mock_client.get_access_token.assert_not_called()


### PR DESCRIPTION
This PR adds an implementation of the request auth interface for performing authenticated requests to SherlockML services. This will later be used in clients implemented in this library.

This PR deliberately does not implement any on-disk caching of the access token - this will be done in a later PR.