### PR TITLE
Configuration module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     install_requires=[
         'requests',
-        'pytz'
+        'pytz',
+        'six'
     ]
 )

--- a/sherlockml/config.py
+++ b/sherlockml/config.py
@@ -5,12 +5,12 @@ from functools import wraps
 from six.moves.configparser import ConfigParser, NoSectionError, NoOptionError
 
 
-Config = namedtuple('Config', ['default_deployment', 'deployments'])
-Deployment = namedtuple(
-    'Deployment',
+Profile = namedtuple(
+    'Profile',
     ['domain', 'protocol', 'client_id', 'client_secret']
 )
 
+DEFAULT_PROFILE = 'default'
 DEFAULT_DOMAIN = 'sherlockml.com'
 DEFAULT_PROTOCOL = 'https'
 
@@ -27,22 +27,17 @@ def load(path):
         except (NoSectionError, NoOptionError):
             return fallback
 
-    default_deployment = _get('default', 'deployment')
-    deployments = {}
+    profiles = {}
 
     for section in parser.sections():
-
-        if section.lower() == 'default':
-            continue
-
-        deployments[section] = Deployment(
+        profiles[section] = Profile(
             domain=_get(section, 'domain', DEFAULT_DOMAIN),
             protocol=_get(section, 'protocol', DEFAULT_PROTOCOL),
             client_id=_get(section, 'client_id'),
             client_secret=_get(section, 'client_secret')
         )
 
-    return Config(default_deployment, deployments)
+    return profiles
 
 
 def env_override(environment_variable):
@@ -64,30 +59,30 @@ def _configuration_path():
     return os.path.join(xdg_config_home, 'sherlockml', 'configuration')
 
 
-def _default_deployment_config():
+def _default_profile():
     config = load(_configuration_path())
-    return config.deployments[config.default_deployment]
+    return config['default']
 
 
 @env_override('SHERLOCKML_DOMAIN')
 def domain():
-    """Return the domain for the default deployment."""
-    return _default_deployment_config().domain
+    """Return the domain for the default profile."""
+    return _default_profile().domain
 
 
 @env_override('SHERLOCKML_PROTOCOL')
 def protocol():
-    """Return the protocol for the default deployment."""
-    return _default_deployment_config().protocol
+    """Return the protocol for the default profile."""
+    return _default_profile().protocol
 
 
 @env_override('SHERLOCKML_CLIENT_ID')
 def client_id():
-    """Return the client ID for the default deployment."""
-    return _default_deployment_config().client_id
+    """Return the client ID for the default profile."""
+    return _default_profile().client_id
 
 
 @env_override('SHERLOCKML_CLIENT_SECRET')
 def client_secret():
-    """Return the client secret for the default deployment."""
-    return _default_deployment_config().client_secret
+    """Return the client secret for the default profile."""
+    return _default_profile().client_secret

--- a/sherlockml/config.py
+++ b/sherlockml/config.py
@@ -63,56 +63,54 @@ def _missing_credentials(type_):
     raise CredentialsError('No {} found'.format(type_))
 
 
-def resolve_profile(configuration_path_override=None,
-                    profile_name_override=None, domain_override=None,
-                    protocol_override=None, client_id_override=None,
-                    client_secret_override=None):
+def resolve_profile(configuration_path=None, profile_name=None, domain=None,
+                    protocol=None, client_id=None, client_secret=None):
 
-    configuration_path = (
-        configuration_path_override
+    resolved_configuration_path = (
+        configuration_path
         or os.getenv('SHERLOCKML_CONFIGURATION')
         or _default_configuration_path()
     )
 
-    profile_name = (
-        profile_name_override
+    resolved_profile_name = (
+        profile_name
         or os.getenv('SHERLOCKML_PROFILE')
         or DEFAULT_PROFILE
     )
 
-    profile = load_profile(configuration_path, profile_name)
+    profile = load_profile(resolved_configuration_path, resolved_profile_name)
 
-    domain = (
-        domain_override
+    resolved_domain = (
+        domain
         or os.getenv('SHERLOCKML_DOMAIN')
         or profile.domain
         or DEFAULT_DOMAIN
     )
 
-    protocol = (
-        protocol_override
+    resolved_protocol = (
+        protocol
         or os.getenv('SHERLOCKML_PROTOCOL')
         or profile.protocol
         or DEFAULT_PROTOCOL
     )
 
-    client_id = (
-        client_id_override
+    resolved_client_id = (
+        client_id
         or os.getenv('SHERLOCKML_CLIENT_ID')
         or profile.client_id
         or _missing_credentials('client_id')
     )
 
-    client_secret = (
-        client_secret_override
+    resolved_client_secret = (
+        client_secret
         or os.getenv('SHERLOCKML_CLIENT_SECRET')
         or profile.client_secret
         or _missing_credentials('client_secret')
     )
 
     return Profile(
-        domain=domain,
-        protocol=protocol,
-        client_id=client_id,
-        client_secret=client_secret
+        domain=resolved_domain,
+        protocol=resolved_protocol,
+        client_id=resolved_client_id,
+        client_secret=resolved_client_secret
     )

--- a/sherlockml/config.py
+++ b/sherlockml/config.py
@@ -1,0 +1,87 @@
+import os
+from collections import namedtuple
+from functools import wraps
+
+from six.moves.configparser import ConfigParser
+
+
+Config = namedtuple('Config', ['default_deployment', 'deployments'])
+Deployment = namedtuple(
+    'Deployment',
+    ['domain', 'protocol', 'client_id', 'client_secret']
+)
+
+DEFAULT_DOMAIN = 'sherlockml.com'
+DEFAULT_PROTOCOL = 'https'
+
+
+def load(path):
+    """Read the SherlockML configuration from a file."""
+
+    parser = ConfigParser()
+    parser.read(str(path))
+
+    default_deployment = parser.get('default', 'deployment', fallback=None)
+    deployments = {}
+
+    for name, section in parser.items():
+
+        if name.lower() == 'default':
+            continue
+
+        deployments[name] = Deployment(
+            domain=section.get('domain', DEFAULT_DOMAIN),
+            protocol=section.get('protocol', DEFAULT_PROTOCOL),
+            client_id=section.get('client_id'),
+            client_secret=section.get('client_secret')
+        )
+
+    return Config(default_deployment, deployments)
+
+
+def env_override(environment_variable):
+    """Override the return value of a function when an env variable is set."""
+    def decorator(func):
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            env_value = os.environ.get(environment_variable)
+            return env_value or func(*args, **kwargs)
+        return wrapped
+    return decorator
+
+
+@env_override('SHERLOCKML_CONFIGURATION')
+def _configuration_path():
+    xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
+    if not xdg_config_home:
+        xdg_config_home = os.path.expanduser('~/.config')
+    return os.path.join(xdg_config_home, 'sherlockml', 'configuration')
+
+
+def _default_deployment_config():
+    config = load(_configuration_path())
+    return config.deployments[config.default_deployment]
+
+
+@env_override('SHERLOCKML_DOMAIN')
+def domain():
+    """Return the domain for the default deployment."""
+    return _default_deployment_config().domain
+
+
+@env_override('SHERLOCKML_PROTOCOL')
+def protocol():
+    """Return the protocol for the default deployment."""
+    return _default_deployment_config().protocol
+
+
+@env_override('SHERLOCKML_CLIENT_ID')
+def client_id():
+    """Return the client ID for the default deployment."""
+    return _default_deployment_config().client_id
+
+
+@env_override('SHERLOCKML_CLIENT_SECRET')
+def client_secret():
+    """Return the client secret for the default deployment."""
+    return _default_deployment_config().client_secret

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,12 +185,12 @@ def test_resolve_profile_defaults(mocker):
 def test_resolve_profile_missing_client_id(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=PROFILE_WITHOUT_ID)
-    with pytest.raises(config.CredentialsError):
+    with pytest.raises(config.CredentialsError, match='client_id'):
         config.resolve_profile()
 
 
 def test_resolve_profile_missing_client_secret(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=PROFILE_WITHOUT_SECRET)
-    with pytest.raises(config.CredentialsError):
+    with pytest.raises(config.CredentialsError, match='client_secret'):
         config.resolve_profile()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,7 +102,7 @@ def test_resolve_profile_configuration_path_override(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=DEFAULT_PROFILE)
 
-    profile = config.resolve_profile(configuration_path_override='test/path')
+    profile = config.resolve_profile(configuration_path='test/path')
     assert profile == DEFAULT_PROFILE
 
     config.load_profile.assert_called_once_with('test/path', 'default')
@@ -123,7 +123,7 @@ def test_resolve_profile_profile_name_override(mocker):
     mocker.patch('sherlockml.config.load_profile', return_value=OTHER_PROFILE)
     mocker.patch('sherlockml.config._default_configuration_path')
 
-    profile = config.resolve_profile(profile_name_override='other')
+    profile = config.resolve_profile(profile_name='other')
     assert profile == OTHER_PROFILE
 
     config.load_profile.assert_called_once_with(
@@ -147,10 +147,10 @@ def test_resolve_profile_overrides(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=DEFAULT_PROFILE)
     profile = config.resolve_profile(
-        domain_override='other.domain.com',
-        protocol_override='other-protocol',
-        client_id_override='other-client-id',
-        client_secret_override='other-client-secret'
+        domain='other.domain.com',
+        protocol='other-protocol',
+        client_id='other-client-id',
+        client_secret='other-client-secret'
     )
     assert profile == OTHER_PROFILE
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,11 +68,10 @@ def test_load_missing():
 ])
 def test_load_profile(mocker, profile_name, expected_profile):
     mocker.patch('sherlockml.config.load', return_value=SAMPLE_CONFIG)
-    path = mocker.Mock()
 
-    assert config.load_profile(path, profile_name) == expected_profile
+    assert config.load_profile('test/path', profile_name) == expected_profile
 
-    config.load.assert_called_once_with(path)
+    config.load.assert_called_once_with('test/path')
 
 
 def test_default_configuration_path(mocker):
@@ -102,12 +101,11 @@ def test_resolve_profile(mocker):
 def test_resolve_profile_configuration_path_override(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=DEFAULT_PROFILE)
-    path = mocker.Mock()
 
-    profile = config.resolve_profile(configuration_path_override=path)
+    profile = config.resolve_profile(configuration_path_override='test/path')
     assert profile == DEFAULT_PROFILE
 
-    config.load_profile.assert_called_once_with(path, 'default')
+    config.load_profile.assert_called_once_with('test/path', 'default')
 
 
 def test_resolve_profile_configuration_path_env(mocker):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from sherlockml import config
@@ -10,23 +12,44 @@ protocol = test-protocol
 client_id = test-client-id
 client_secret = test-client-secret
 
-[Profile with Defaults]
+[empty profile]
 """
 
-SAMPLE_CONFIG = {
-    'default': config.Profile(
-        domain='test.domain.com',
-        protocol='test-protocol',
-        client_id='test-client-id',
-        client_secret='test-client-secret'
-    ),
-    'Profile with Defaults': config.Profile(
-        domain='sherlockml.com',
-        protocol='https',
-        client_id=None,
-        client_secret=None
-    )
-}
+DEFAULT_PROFILE = config.Profile(
+    domain='test.domain.com',
+    protocol='test-protocol',
+    client_id='test-client-id',
+    client_secret='test-client-secret'
+)
+OTHER_PROFILE = config.Profile(
+    domain='other.domain.com',
+    protocol='other-protocol',
+    client_id='other-client-id',
+    client_secret='other-client-secret'
+)
+CREDENTIALS_ONLY_PROFILE = config.Profile(
+    domain=None,
+    protocol=None,
+    client_id='test-client-id',
+    client_secret='test-client-secret'
+)
+PROFILE_WITHOUT_ID = config.Profile(
+    domain='test.domain.com',
+    protocol='test-protocol',
+    client_id=None,
+    client_secret='test-client-secret'
+)
+PROFILE_WITHOUT_SECRET = config.Profile(
+    domain='test.domain.com',
+    protocol='test-protocol',
+    client_id='test-client-id',
+    client_secret=None
+)
+EMPTY_PROFILE = config.Profile(
+    domain=None, protocol=None, client_id=None, client_secret=None
+)
+
+SAMPLE_CONFIG = {'default': DEFAULT_PROFILE, 'empty profile': EMPTY_PROFILE}
 
 
 @pytest.fixture
@@ -44,21 +67,137 @@ def test_load_missing():
     assert config.load('does-not-exist') == {}
 
 
-@pytest.mark.parametrize(
-    'override_value, expected_return_value',
-    [
-        ('override', 'override'),
-        ('', 'normal'),
-        (None, 'normal')
-    ]
-)
-def test_env_override(monkeypatch, override_value, expected_return_value):
+@pytest.mark.parametrize('profile_name, expected_profile', [
+    ('default', DEFAULT_PROFILE),
+    ('missing profile', EMPTY_PROFILE)
+])
+def test_load_profile(mocker, profile_name, expected_profile):
+    mocker.patch('sherlockml.config.load', return_value=SAMPLE_CONFIG)
+    path = mocker.Mock()
 
-    if override_value is not None:
-        monkeypatch.setenv('EXAMPLE', override_value)
+    assert config.load_profile(path, profile_name) == expected_profile
 
-    @config.env_override('EXAMPLE')
-    def test():
-        return 'normal'
+    config.load.assert_called_once_with(path)
 
-    assert test() == expected_return_value
+
+def test_default_configuration_path(mocker):
+    mocker.patch.dict(os.environ, {'HOME': '/foo/bar'})
+    expected_path = '/foo/bar/.config/sherlockml/configuration'
+    assert config._default_configuration_path() == expected_path
+
+
+def test_default_configuration_path_xdg_home(mocker):
+    mocker.patch.dict(os.environ, {'XDG_CONFIG_HOME': '/xdg/home'})
+    expected_path = '/xdg/home/sherlockml/configuration'
+    assert config._default_configuration_path() == expected_path
+
+
+def test_resolve_profile(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=DEFAULT_PROFILE)
+    mocker.patch('sherlockml.config._default_configuration_path')
+
+    assert config.resolve_profile() == DEFAULT_PROFILE
+
+    config.load_profile.assert_called_once_with(
+        config._default_configuration_path.return_value, 'default'
+    )
+
+
+def test_resolve_profile_configuration_path_override(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=DEFAULT_PROFILE)
+    path = mocker.Mock()
+
+    profile = config.resolve_profile(configuration_path_override=path)
+    assert profile == DEFAULT_PROFILE
+
+    config.load_profile.assert_called_once_with(path, 'default')
+
+
+def test_resolve_profile_configuration_path_env(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=DEFAULT_PROFILE)
+    path = '/path/to/configuration'
+    mocker.patch.dict(os.environ, {'SHERLOCKML_CONFIGURATION': path})
+
+    assert config.resolve_profile() == DEFAULT_PROFILE
+
+    config.load_profile.assert_called_once_with(path, 'default')
+
+
+def test_resolve_profile_profile_name_override(mocker):
+    mocker.patch('sherlockml.config.load_profile', return_value=OTHER_PROFILE)
+    mocker.patch('sherlockml.config._default_configuration_path')
+
+    profile = config.resolve_profile(profile_name_override='other')
+    assert profile == OTHER_PROFILE
+
+    config.load_profile.assert_called_once_with(
+        config._default_configuration_path.return_value, 'other'
+    )
+
+
+def test_resolve_profile_profile_name_env(mocker):
+    mocker.patch('sherlockml.config.load_profile', return_value=OTHER_PROFILE)
+    mocker.patch('sherlockml.config._default_configuration_path')
+    mocker.patch.dict(os.environ, {'SHERLOCKML_PROFILE': 'other'})
+
+    assert config.resolve_profile() == OTHER_PROFILE
+
+    config.load_profile.assert_called_once_with(
+        config._default_configuration_path.return_value, 'other'
+    )
+
+
+def test_resolve_profile_overrides(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=DEFAULT_PROFILE)
+    profile = config.resolve_profile(
+        domain_override='other.domain.com',
+        protocol_override='other-protocol',
+        client_id_override='other-client-id',
+        client_secret_override='other-client-secret'
+    )
+    assert profile == OTHER_PROFILE
+
+
+def test_resolve_profile_env(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=DEFAULT_PROFILE)
+    mocker.patch.dict(
+        os.environ,
+        {
+            'SHERLOCKML_DOMAIN': 'other.domain.com',
+            'SHERLOCKML_PROTOCOL': 'other-protocol',
+            'SHERLOCKML_CLIENT_ID': 'other-client-id',
+            'SHERLOCKML_CLIENT_SECRET': 'other-client-secret'
+        }
+    )
+    assert config.resolve_profile() == OTHER_PROFILE
+
+
+def test_resolve_profile_defaults(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=CREDENTIALS_ONLY_PROFILE)
+    profile = config.resolve_profile()
+    assert profile == config.Profile(
+        domain=config.DEFAULT_DOMAIN,
+        protocol=config.DEFAULT_PROTOCOL,
+        client_id='test-client-id',
+        client_secret='test-client-secret'
+    )
+
+
+def test_resolve_profile_missing_client_id(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=PROFILE_WITHOUT_ID)
+    with pytest.raises(config.CredentialsError):
+        config.resolve_profile()
+
+
+def test_resolve_profile_missing_client_secret(mocker):
+    mocker.patch('sherlockml.config.load_profile',
+                 return_value=PROFILE_WITHOUT_SECRET)
+    with pytest.raises(config.CredentialsError):
+        config.resolve_profile()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,34 +5,28 @@ from sherlockml import config
 
 SAMPLE_CONFIG_CONTENT = """
 [default]
-deployment = A Deployment
-
-[A Deployment]
 domain = test.domain.com
 protocol = test-protocol
 client_id = test-client-id
 client_secret = test-client-secret
 
-[Deployment with Defaults]
+[Profile with Defaults]
 """
 
-SAMPLE_CONFIG = config.Config(
-    default_deployment='A Deployment',
-    deployments={
-        'A Deployment': config.Deployment(
-            domain='test.domain.com',
-            protocol='test-protocol',
-            client_id='test-client-id',
-            client_secret='test-client-secret'
-        ),
-        'Deployment with Defaults': config.Deployment(
-            domain='sherlockml.com',
-            protocol='https',
-            client_id=None,
-            client_secret=None
-        )
-    }
-)
+SAMPLE_CONFIG = {
+    'default': config.Profile(
+        domain='test.domain.com',
+        protocol='test-protocol',
+        client_id='test-client-id',
+        client_secret='test-client-secret'
+    ),
+    'Profile with Defaults': config.Profile(
+        domain='sherlockml.com',
+        protocol='https',
+        client_id=None,
+        client_secret=None
+    )
+}
 
 
 @pytest.fixture
@@ -47,12 +41,16 @@ def test_load(sample_config):
 
 
 def test_load_missing():
-    assert config.load('does-not-exist') == config.Config(None, {})
+    assert config.load('does-not-exist') == {}
 
 
 @pytest.mark.parametrize(
     'override_value, expected_return_value',
-    [('override', 'override'), ('', 'normal'), (None, 'normal')]
+    [
+        ('override', 'override'),
+        ('', 'normal'),
+        (None, 'normal')
+    ]
 )
 def test_env_override(monkeypatch, override_value, expected_return_value):
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,66 @@
+import pytest
+
+from sherlockml import config
+
+
+SAMPLE_CONFIG_CONTENT = """
+[default]
+deployment = A Deployment
+
+[A Deployment]
+domain = test.domain.com
+protocol = test-protocol
+client_id = test-client-id
+client_secret = test-client-secret
+
+[Deployment with Defaults]
+"""
+
+SAMPLE_CONFIG = config.Config(
+    default_deployment='A Deployment',
+    deployments={
+        'A Deployment': config.Deployment(
+            domain='test.domain.com',
+            protocol='test-protocol',
+            client_id='test-client-id',
+            client_secret='test-client-secret'
+        ),
+        'Deployment with Defaults': config.Deployment(
+            domain='sherlockml.com',
+            protocol='https',
+            client_id=None,
+            client_secret=None
+        )
+    }
+)
+
+
+@pytest.fixture
+def sample_config(tmpdir):
+    file = tmpdir.join('config')
+    file.write(SAMPLE_CONFIG_CONTENT)
+    return file
+
+
+def test_load(sample_config):
+    assert config.load(sample_config) == SAMPLE_CONFIG
+
+
+def test_load_missing():
+    assert config.load('does-not-exist') == config.Config(None, {})
+
+
+@pytest.mark.parametrize(
+    'override_value, expected_return_value',
+    [('override', 'override'), ('', 'normal'), (None, 'normal')]
+)
+def test_env_override(monkeypatch, override_value, expected_return_value):
+
+    if override_value is not None:
+        monkeypatch.setenv('EXAMPLE', override_value)
+
+    @config.env_override('EXAMPLE')
+    def test():
+        return 'normal'
+
+    assert test() == expected_return_value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,15 +52,10 @@ EMPTY_PROFILE = config.Profile(
 SAMPLE_CONFIG = {'default': DEFAULT_PROFILE, 'empty profile': EMPTY_PROFILE}
 
 
-@pytest.fixture
-def sample_config(tmpdir):
+def test_load(tmpdir):
     file = tmpdir.join('config')
     file.write(SAMPLE_CONFIG_CONTENT)
-    return file
-
-
-def test_load(sample_config):
-    assert config.load(sample_config) == SAMPLE_CONFIG
+    assert config.load(file) == SAMPLE_CONFIG
 
 
 def test_load_missing():


### PR DESCRIPTION
This PR implements a module for reading configuration, including a function for resolving:

* Configuration passed in programatically (called 'overrides' in the code)
* Configuration set with environment variables
* Configuration read from file
* Configuration defaults

This would be used in client code as follows:

```python
from sherlockml import config

class SomeClient(object):

    def __init__(self, configuration_path=None, profile_name=None, domain=None,
                 protocol=None, client_id=None, client_secret=None):

        profile = config.resolve_profile(
            configuration_path_override=configuration_path,
            profile_name_override=profile_name,
            domain_override=domain,
            protocol_override=protocol,
            client_id_override=client_id,
            client_secret_override=client_secret
        )
        # Use or store the profile
```

This therefore enables a client API similar to boto, where by default, configuration has defaults, and configuration and credentials are read from the environment and configuration files, but can be overridden in code.

The configuration files read here are backwards compatible with `sml`, but to avoid ambiguity, the 'SherlockML env' concept is dropped and replaced with a 'SherlockML profile'. This is more similar to boto, and importantly avoids the current double use of `SHERLOCKML_ENV` for selecting both different domains and credential sets. An example file would be:

```ini
[default]
domain = sherlockml.com
protocol = https
client_id = my-client-id
client_secret = my-client-secret
```