### PR TITLE
Rename credentials file and other tweaks

### DIFF
--- a/sherlockml/config.py
+++ b/sherlockml/config.py
@@ -59,7 +59,7 @@ class CredentialsError(RuntimeError):
     pass
 
 
-def _missing_credentials(type_):
+def _raise_credentials_error(type_):
     raise CredentialsError('No {} found'.format(type_))
 
 
@@ -98,14 +98,14 @@ def resolve_profile(credentials_path=None, profile_name=None, domain=None,
         client_id
         or os.getenv('SHERLOCKML_CLIENT_ID')
         or profile.client_id
-        or _missing_credentials('client_id')
+        or _raise_credentials_error('client_id')
     )
 
     resolved_client_secret = (
         client_secret
         or os.getenv('SHERLOCKML_CLIENT_SECRET')
         or profile.client_secret
-        or _missing_credentials('client_secret')
+        or _raise_credentials_error('client_secret')
     )
 
     return Profile(

--- a/sherlockml/config.py
+++ b/sherlockml/config.py
@@ -48,11 +48,11 @@ def load_profile(path, profile):
         return Profile(None, None, None, None)
 
 
-def _default_configuration_path():
+def _default_credentials_path():
     xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
     if not xdg_config_home:
         xdg_config_home = os.path.expanduser('~/.config')
-    return os.path.join(xdg_config_home, 'sherlockml', 'configuration')
+    return os.path.join(xdg_config_home, 'sherlockml', 'credentials')
 
 
 class CredentialsError(RuntimeError):
@@ -63,13 +63,13 @@ def _missing_credentials(type_):
     raise CredentialsError('No {} found'.format(type_))
 
 
-def resolve_profile(configuration_path=None, profile_name=None, domain=None,
+def resolve_profile(credentials_path=None, profile_name=None, domain=None,
                     protocol=None, client_id=None, client_secret=None):
 
-    resolved_configuration_path = (
-        configuration_path
-        or os.getenv('SHERLOCKML_CONFIGURATION')
-        or _default_configuration_path()
+    resolved_credentials_path = (
+        credentials_path
+        or os.getenv('SHERLOCKML_CREDENTIALS')
+        or _default_credentials_path()
     )
 
     resolved_profile_name = (
@@ -78,7 +78,7 @@ def resolve_profile(configuration_path=None, profile_name=None, domain=None,
         or DEFAULT_PROFILE
     )
 
-    profile = load_profile(resolved_configuration_path, resolved_profile_name)
+    profile = load_profile(resolved_credentials_path, resolved_profile_name)
 
     resolved_domain = (
         domain

--- a/sherlockml/config.py
+++ b/sherlockml/config.py
@@ -68,7 +68,7 @@ def resolve_profile(credentials_path=None, profile_name=None, domain=None,
 
     resolved_credentials_path = (
         credentials_path
-        or os.getenv('SHERLOCKML_CREDENTIALS')
+        or os.getenv('SHERLOCKML_CREDENTIALS_PATH')
         or _default_credentials_path()
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,7 +112,7 @@ def test_resolve_profile_credentials_path_env(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=DEFAULT_PROFILE)
     path = '/path/to/credentials'
-    mocker.patch.dict(os.environ, {'SHERLOCKML_CREDENTIALS': path})
+    mocker.patch.dict(os.environ, {'SHERLOCKML_CREDENTIALS_PATH': path})
 
     assert config.resolve_profile() == DEFAULT_PROFILE
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,45 +74,45 @@ def test_load_profile(mocker, profile_name, expected_profile):
     config.load.assert_called_once_with('test/path')
 
 
-def test_default_configuration_path(mocker):
+def test_default_credentials_path(mocker):
     mocker.patch.dict(os.environ, {'HOME': '/foo/bar'})
-    expected_path = '/foo/bar/.config/sherlockml/configuration'
-    assert config._default_configuration_path() == expected_path
+    expected_path = '/foo/bar/.config/sherlockml/credentials'
+    assert config._default_credentials_path() == expected_path
 
 
-def test_default_configuration_path_xdg_home(mocker):
+def test_default_credentials_path_xdg_home(mocker):
     mocker.patch.dict(os.environ, {'XDG_CONFIG_HOME': '/xdg/home'})
-    expected_path = '/xdg/home/sherlockml/configuration'
-    assert config._default_configuration_path() == expected_path
+    expected_path = '/xdg/home/sherlockml/credentials'
+    assert config._default_credentials_path() == expected_path
 
 
 def test_resolve_profile(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=DEFAULT_PROFILE)
-    mocker.patch('sherlockml.config._default_configuration_path')
+    mocker.patch('sherlockml.config._default_credentials_path')
 
     assert config.resolve_profile() == DEFAULT_PROFILE
 
     config.load_profile.assert_called_once_with(
-        config._default_configuration_path.return_value, 'default'
+        config._default_credentials_path.return_value, 'default'
     )
 
 
-def test_resolve_profile_configuration_path_override(mocker):
+def test_resolve_profile_credentials_path_override(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=DEFAULT_PROFILE)
 
-    profile = config.resolve_profile(configuration_path='test/path')
+    profile = config.resolve_profile(credentials_path='test/path')
     assert profile == DEFAULT_PROFILE
 
     config.load_profile.assert_called_once_with('test/path', 'default')
 
 
-def test_resolve_profile_configuration_path_env(mocker):
+def test_resolve_profile_credentials_path_env(mocker):
     mocker.patch('sherlockml.config.load_profile',
                  return_value=DEFAULT_PROFILE)
-    path = '/path/to/configuration'
-    mocker.patch.dict(os.environ, {'SHERLOCKML_CONFIGURATION': path})
+    path = '/path/to/credentials'
+    mocker.patch.dict(os.environ, {'SHERLOCKML_CREDENTIALS': path})
 
     assert config.resolve_profile() == DEFAULT_PROFILE
 
@@ -121,25 +121,25 @@ def test_resolve_profile_configuration_path_env(mocker):
 
 def test_resolve_profile_profile_name_override(mocker):
     mocker.patch('sherlockml.config.load_profile', return_value=OTHER_PROFILE)
-    mocker.patch('sherlockml.config._default_configuration_path')
+    mocker.patch('sherlockml.config._default_credentials_path')
 
     profile = config.resolve_profile(profile_name='other')
     assert profile == OTHER_PROFILE
 
     config.load_profile.assert_called_once_with(
-        config._default_configuration_path.return_value, 'other'
+        config._default_credentials_path.return_value, 'other'
     )
 
 
 def test_resolve_profile_profile_name_env(mocker):
     mocker.patch('sherlockml.config.load_profile', return_value=OTHER_PROFILE)
-    mocker.patch('sherlockml.config._default_configuration_path')
+    mocker.patch('sherlockml.config._default_credentials_path')
     mocker.patch.dict(os.environ, {'SHERLOCKML_PROFILE': 'other'})
 
     assert config.resolve_profile() == OTHER_PROFILE
 
     config.load_profile.assert_called_once_with(
-        config._default_configuration_path.return_value, 'other'
+        config._default_credentials_path.return_value, 'other'
     )
 
 


### PR DESCRIPTION
As discussed in today's meeting, this PR:

* Renames configuration to credentials, keeping backwards compatability with sml
* Adds the _PATH suffix to the credentials environment variable
* Renames a helper method for clarity