### PR TITLE
Test Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 script:
   - pip install flake8
   - flake8


### PR DESCRIPTION
Include the recently released Python 3.7 in CI tests.