### PR TITLE
Use marshmallow 3 beta

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,11 @@ setup(
         'pytz',
         'six',
         "enum34; python_version<'3.4'",
-        'marshmallow<3.0.0',
+        'marshmallow==3.0.0b12',
         'marshmallow_enum'
+    ],
+    dependency_links=[
+        'git+https://github.com/marshmallow-code/marshmallow'
+        '@3.0.0b12#egg=marshmallow'
     ]
 )

--- a/sherlockml/clients/base.py
+++ b/sherlockml/clients/base.py
@@ -19,12 +19,6 @@ from six.moves import urllib
 from sherlockml.clients.auth import SherlockMLAuth
 
 
-class BaseSchema(marshmallow.Schema):
-
-    def __init__(self, *args, **kwargs):
-        super(BaseSchema, self).__init__(*args, strict=True, **kwargs)
-
-
 class BadResponseStatus(Exception):
 
     def __init__(self, response):
@@ -65,7 +59,7 @@ def _deserialise_response(schema, response):
         raise InvalidResponse('response body was not valid JSON')
 
     try:
-        data, _ = schema.load(response_json)
+        data = schema.load(response_json)
     except marshmallow.ValidationError:
         # TODO: log validation errors and possibly include them in raised
         # exception

--- a/sherlockml/clients/cluster.py
+++ b/sherlockml/clients/cluster.py
@@ -15,9 +15,9 @@
 
 from collections import namedtuple
 
-from marshmallow import fields, post_load
+from marshmallow import Schema, fields, post_load
 
-from sherlockml.clients.base import BaseSchema, BaseClient
+from sherlockml.clients.base import BaseClient
 
 
 NodeType = namedtuple(
@@ -28,7 +28,7 @@ NodeType = namedtuple(
 )
 
 
-class NodeTypeSchema(BaseSchema):
+class NodeTypeSchema(Schema):
 
     nodeTypeId = fields.String(required=True)
     name = fields.String(missing=None)

--- a/sherlockml/clients/project.py
+++ b/sherlockml/clients/project.py
@@ -15,15 +15,15 @@
 
 from collections import namedtuple
 
-from marshmallow import fields, post_load
+from marshmallow import Schema, fields, post_load
 
-from sherlockml.clients.base import BaseSchema, BaseClient
+from sherlockml.clients.base import BaseClient
 
 
 Project = namedtuple('Project', ['id', 'name', 'owner_id'])
 
 
-class ProjectSchema(BaseSchema):
+class ProjectSchema(Schema):
     projectId = fields.UUID(required=True)
     name = fields.Str(required=True)
     ownerId = fields.UUID(required=True)

--- a/sherlockml/clients/server.py
+++ b/sherlockml/clients/server.py
@@ -16,10 +16,10 @@
 from collections import namedtuple
 from enum import Enum
 
-from marshmallow import fields, post_load
+from marshmallow import Schema, fields, post_load
 from marshmallow_enum import EnumField
 
-from sherlockml.clients.base import BaseSchema, BaseClient
+from sherlockml.clients.base import BaseClient
 
 
 class ServerStatus(Enum):
@@ -32,7 +32,7 @@ class ServerStatus(Enum):
 Service = namedtuple('Service', ['name', 'host', 'port', 'scheme', 'uri'])
 
 
-class ServiceSchema(BaseSchema):
+class ServiceSchema(Schema):
 
     name = fields.Str(required=True)
     host = fields.Str(required=True)
@@ -51,7 +51,7 @@ Server = namedtuple('Server', [
 ])
 
 
-class ServerSchema(BaseSchema):
+class ServerSchema(Schema):
 
     instanceId = fields.UUID(required=True)
     projectId = fields.UUID(required=True)
@@ -80,7 +80,7 @@ class ServerSchema(BaseSchema):
         )
 
 
-class ServerIdSchema(BaseSchema):
+class ServerIdSchema(Schema):
 
     instanceId = fields.UUID(required=True)
 

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -15,15 +15,15 @@
 
 from collections import namedtuple
 
-from marshmallow import fields, post_load
+from marshmallow import Schema, fields, post_load
 
-from sherlockml.clients.base import BaseSchema, BaseClient
+from sherlockml.clients.base import BaseClient
 
 
 User = namedtuple('User', ['id'])
 
 
-class UserSchema(BaseSchema):
+class UserSchema(Schema):
     userId = fields.UUID(required=True)
 
     @post_load
@@ -34,7 +34,7 @@ class UserSchema(BaseSchema):
 AuthenticationResponse = namedtuple('AuthenticationResponse', ['user'])
 
 
-class AuthenticationResponseSchema(BaseSchema):
+class AuthenticationResponseSchema(Schema):
     account = fields.Nested(UserSchema, required=True)
 
     @post_load

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -16,11 +16,10 @@
 from collections import namedtuple
 
 import pytest
-from marshmallow import fields, post_load
+from marshmallow import Schema, fields, post_load
 
 from sherlockml.clients.base import (
-    BaseSchema, BaseClient, Unauthorized, NotFound, BadResponseStatus,
-    InvalidResponse
+    BaseClient, Unauthorized, NotFound, BadResponseStatus, InvalidResponse
 )
 from tests.clients.fixtures import PROFILE
 
@@ -59,7 +58,7 @@ def patch_sherlockmlauth(mocker):
 DummyObject = namedtuple('DummyObject', ['foo'])
 
 
-class DummySchema(BaseSchema):
+class DummySchema(Schema):
     foo = fields.String(required=True)
 
     @post_load

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -76,12 +76,12 @@ NODE_TYPE_BODY_DEFAULT = {
 
 
 def test_node_type_schema():
-    data, _ = NodeTypeSchema().load(NODE_TYPE_BODY)
+    data = NodeTypeSchema().load(NODE_TYPE_BODY)
     assert data == NODE_TYPE
 
 
 def test_node_type_schema_with_defaults():
-    data, _ = NodeTypeSchema().load(NODE_TYPE_BODY_DEFAULT)
+    data = NodeTypeSchema().load(NODE_TYPE_BODY_DEFAULT)
     assert data == NODE_TYPE_DEFAULT
 
 

--- a/tests/clients/test_project.py
+++ b/tests/clients/test_project.py
@@ -38,7 +38,7 @@ PROJECT_BODY = {
 
 
 def test_project_schema():
-    data, _ = ProjectSchema().load(PROJECT_BODY)
+    data = ProjectSchema().load(PROJECT_BODY)
     assert data == PROJECT
 
 

--- a/tests/clients/test_server.py
+++ b/tests/clients/test_server.py
@@ -79,7 +79,7 @@ SERVER_ID_BODY = {'instanceId': str(SERVER_ID)}
 
 
 def test_service_schema():
-    data, _ = ServiceSchema().load(SERVICE_BODY)
+    data = ServiceSchema().load(SERVICE_BODY)
     assert data == SERVICE
 
 
@@ -89,7 +89,7 @@ def test_service_schema_invalid():
 
 
 def test_server_schema():
-    data, _ = ServerSchema().load(SERVER_BODY)
+    data = ServerSchema().load(SERVER_BODY)
     assert data == SERVER
 
 
@@ -99,7 +99,7 @@ def test_server_schema_invalid():
 
 
 def test_server_id_schema():
-    data, _ = ServerIdSchema().load(SERVER_ID_BODY)
+    data = ServerIdSchema().load(SERVER_ID_BODY)
     assert data == SERVER_ID
 
 

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -28,7 +28,7 @@ USER_ID = uuid.uuid4()
 
 
 def test_user_schema():
-    data, _ = UserSchema().load({'userId': str(USER_ID)})
+    data = UserSchema().load({'userId': str(USER_ID)})
     assert data == User(id=USER_ID)
 
 
@@ -41,7 +41,7 @@ def test_user_schema_invalid(data):
 
 
 def test_authentication_response_schema():
-    data, _ = AuthenticationResponseSchema().load(
+    data = AuthenticationResponseSchema().load(
         {'account': {'userId': str(USER_ID)}}
     )
     assert data == AuthenticationResponse(user=User(id=USER_ID))


### PR DESCRIPTION
Pinning to 3.0.0b12 to avoid accidental API changes between beta versions or final release.