### PR TITLE
Rename cluster client query parameters

### DIFF
--- a/sherlockml/clients/cluster.py
+++ b/sherlockml/clients/cluster.py
@@ -62,17 +62,18 @@ class ClusterClient(BaseClient):
     SERVICE_NAME = 'klostermann'
 
     def list_single_tenanted_node_types(
-        self, has_interactive_instances=None, has_job_instances=None
+        self, interactive_instances_configured=None,
+        job_instances_configured=None
     ):
         """Get information on single tenanted node types from the cluster.
 
         Parameters
         ----------
-        has_interactive_instances : bool, optional
+        interactive_instances_configured : bool, optional
             If True, only get node types which are configured to support
             interactive instances, or if False, those which are not configured
             to support interactive instances
-        has_job_instances : bool, optional
+        job_instances_configured : bool, optional
             If True, only get node types which are configured to support job
             instances, or if False, those which are not configured to support
             job instances
@@ -83,13 +84,13 @@ class ClusterClient(BaseClient):
         """
 
         query_params = {}
-        if has_interactive_instances is not None:
-            query_params['hasInteractiveInstances'] = (
-                'true' if has_interactive_instances else 'false'
+        if interactive_instances_configured is not None:
+            query_params['interactiveInstancesConfigured'] = (
+                'true' if interactive_instances_configured else 'false'
             )
-        if has_job_instances is not None:
-            query_params['hasJobInstances'] = (
-                'true' if has_job_instances else 'false'
+        if job_instances_configured is not None:
+            query_params['jobInstancesConfigured'] = (
+                'true' if job_instances_configured else 'false'
             )
 
         return self._get(

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -93,28 +93,32 @@ def test_node_type_schema_load_invalid():
 @pytest.mark.parametrize('kwargs, query_params', [
     ({}, {}),
     (
-        {'has_interactive_instances': True},
-        {'hasInteractiveInstances': 'true'}
+        {'interactive_instances_configured': True},
+        {'interactiveInstancesConfigured': 'true'}
     ),
     (
-        {'has_interactive_instances': False},
-        {'hasInteractiveInstances': 'false'}
+        {'interactive_instances_configured': False},
+        {'interactiveInstancesConfigured': 'false'}
     ),
     (
-        {'has_job_instances': True},
-        {'hasJobInstances': 'true'}
+        {'job_instances_configured': True},
+        {'jobInstancesConfigured': 'true'}
     ),
     (
-        {'has_job_instances': False},
-        {'hasJobInstances': 'false'}
+        {'job_instances_configured': False},
+        {'jobInstancesConfigured': 'false'}
     ),
     (
-        {'has_interactive_instances': True, 'has_job_instances': True},
-        {'hasInteractiveInstances': 'true', 'hasJobInstances': 'true'}
+        {'interactive_instances_configured': True,
+         'job_instances_configured': True},
+        {'interactiveInstancesConfigured': 'true',
+         'jobInstancesConfigured': 'true'}
     ),
     (
-        {'has_interactive_instances': True, 'has_job_instances': False},
-        {'hasInteractiveInstances': 'true', 'hasJobInstances': 'false'}
+        {'interactive_instances_configured': True,
+         'job_instances_configured': False},
+        {'interactiveInstancesConfigured': 'true',
+         'jobInstancesConfigured': 'false'}
     )
 ])
 def test_cluster_client_list_single_tenanted_node_types(


### PR DESCRIPTION
We decided to rename these query parameters in Klostermann, so am updating them here.