### PR TITLE
Add SherlockML datasets (SFS)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,9 @@ setup(
         'six',
         "enum34; python_version<'3.4'",
         'marshmallow==3.0.0b12',
-        'marshmallow_enum'
+        'marshmallow_enum',
+        'boto3',
+        'botocore'
     ],
     dependency_links=[
         'git+https://github.com/marshmallow-code/marshmallow'

--- a/sherlockml/clients/__init__.py
+++ b/sherlockml/clients/__init__.py
@@ -17,13 +17,15 @@ from sherlockml.clients.user import UserClient
 from sherlockml.clients.project import ProjectClient
 from sherlockml.clients.server import ServerClient
 from sherlockml.clients.cluster import ClusterClient
+from sherlockml.clients.secret import SecretClient
 
 
 CLIENT_FOR_RESOURCE = {
     'user': UserClient,
     'project': ProjectClient,
     'server': ServerClient,
-    'cluster': ClusterClient
+    'cluster': ClusterClient,
+    'secret': SecretClient
 }
 
 

--- a/sherlockml/clients/secret.py
+++ b/sherlockml/clients/secret.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from collections import namedtuple
 
 from marshmallow import Schema, fields, post_load
 
 from sherlockml.clients.base import BaseClient
-
 
 DatasetsSecrets = namedtuple(
     'DatasetsSecrets', ['bucket', 'access_key', 'secret_key', 'verified']

--- a/sherlockml/clients/secret.py
+++ b/sherlockml/clients/secret.py
@@ -1,0 +1,45 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections import namedtuple
+
+from marshmallow import Schema, fields, post_load
+
+from sherlockml.clients.base import BaseClient
+
+
+DatasetsSecrets = namedtuple(
+    'DatasetsSecrets', ['bucket', 'access_key', 'secret_key', 'verified']
+)
+
+
+class DatasetsSecretsSchema(Schema):
+    bucket = fields.String(required=True)
+    access_key = fields.String(required=True)
+    secret_key = fields.String(required=True)
+    verified = fields.Boolean(required=True)
+
+    @post_load
+    def make_project_datasets_secrets(self, data):
+        return DatasetsSecrets(**data)
+
+
+class SecretClient(BaseClient):
+
+    SERVICE_NAME = 'secret-service'
+
+    def datasets_secrets(self, project_id):
+        endpoint = 'sfs/{}'.format(project_id)
+        return self._get(endpoint, DatasetsSecretsSchema())

--- a/sherlockml/datasets/__init__.py
+++ b/sherlockml/datasets/__init__.py
@@ -329,7 +329,7 @@ def _get_directory(project_path, local_path, project_id, s3_client):
 
     # Firstly, make sure that the location to write to locally exists
     containing_dir = os.path.dirname(local_path)
-    if len(containing_dir) == 0:
+    if not containing_dir:
         containing_dir = '.'
     if not os.path.isdir(containing_dir):
         msg = 'No such directory: {}'.format(repr(containing_dir))

--- a/sherlockml/datasets/__init__.py
+++ b/sherlockml/datasets/__init__.py
@@ -106,9 +106,7 @@ def ls(prefix='/', project_id=None, show_hidden=False, s3_client=None):
     else:
         non_hidden_paths = [
             path_ for path_ in paths
-            if not any(
-                [element.startswith('.') for element in path_.split('/')]
-            )
+            if not any(element.startswith('.') for element in path_.split('/'))
         ]
         return non_hidden_paths
 
@@ -202,7 +200,7 @@ def _isfile(project_path, project_id=None, s3_client=None):
         s3_client=s3_client
     )
     rationalised_path = path.rationalise_projectpath(project_path)
-    return any([match == rationalised_path for match in matches])
+    return any(match == rationalised_path for match in matches)
 
 
 def _create_parent_directories(project_path, project_id, s3_client):

--- a/sherlockml/datasets/__init__.py
+++ b/sherlockml/datasets/__init__.py
@@ -31,7 +31,7 @@ SherlockMLFileSystemError = SherlockMLDatasetsError
 
 
 def _s3_client(project_id=None):
-    """ Generate a boto S3 client to access this project's SFS directory. """
+    """Generate a boto S3 client to access this project's datasets."""
 
     # At present, calls to the interface of this module run this function once
     # to generate an S3 client, then pass it around to avoid making many calls
@@ -48,18 +48,17 @@ def _s3_client(project_id=None):
 
 
 def _bucket(project_id=None):
-    """ Get SFS bucket from Secret Service. """
     return session.get().bucket(project_id)
 
 
 def ls(prefix='/', project_id=None, show_hidden=False, s3_client=None):
-    """ List contents of project SFS directory.
+    """List contents of project datasets.
 
     Parameters
     ----------
     prefix : str, optional
-        List only files in the project directory matching this prefix. Default
-        behaviour is to list all files.
+        List only files in the datasets matching this prefix. Default behaviour
+        is to list all files.
     project_id : str, optional
         The project to list files from. You need to have access to this project
         for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
@@ -72,7 +71,7 @@ def ls(prefix='/', project_id=None, show_hidden=False, s3_client=None):
     Returns
     -------
     list
-        The list of files from the project.
+        The list of files from the project datasets.
     """
 
     if s3_client is None:
@@ -116,21 +115,19 @@ def ls(prefix='/', project_id=None, show_hidden=False, s3_client=None):
 
 def glob(pattern, prefix='/', project_id=None, show_hidden=False,
          s3_client=None):
-    """
-    List contents of project SFS directory that match
-    a glob pattern.
+    """List contents of project datasets that match a glob pattern.
 
     Parameters
     ----------
     pattern : str
         The pattern that contents need to match.
     prefix : str, optional
-        List only files in the project directory that have
-        this prefix. Default behaviour is to list all files.
+        List only files in the project datasets that have this prefix. Default
+        behaviour is to list all files.
     project_id : str, optional
-        The project to list files from. You need to have access
-        to this project for it to work. Defaults to the project
-        set by SHERLOCK_PROJECT_ID in your environment.
+        The project to list files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCK_PROJECT_ID in
+        your environment.
     show_hidden : bool, optional
         Include hidden files in the output. Defaults to False.
     s3_client : botocore.client.S3, optional
@@ -139,8 +136,7 @@ def glob(pattern, prefix='/', project_id=None, show_hidden=False,
     Returns
     -------
     list
-        The list of files from the project that match
-        the glob pattern.
+        The list of files from the project that match the glob pattern.
     """
 
     contents = ls(prefix=prefix, project_id=project_id,
@@ -150,12 +146,12 @@ def glob(pattern, prefix='/', project_id=None, show_hidden=False,
 
 
 def _isdir(project_path, project_id=None, s3_client=None):
-    """ Determine if a path in the project directory is a directory.
+    """Determine if a path in a project's datasets is a directory.
 
     Parameters
     ----------
     project_path : str
-        The path in the project directory to test.
+        The path in the project datasets to test.
     project_id : str, optional
         The project to list files from. You need to have access to this project
         for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
@@ -180,7 +176,7 @@ def _isdir(project_path, project_id=None, s3_client=None):
 
 
 def _isfile(project_path, project_id=None, s3_client=None):
-    """ Determine if a path in the project directory is a file.
+    """Determine if a path in a project's datasets is a file.
 
     Parameters
     ----------
@@ -278,8 +274,7 @@ def _put_directory(local_path, project_path, project_id, s3_client):
 
 
 def _put_recursive(local_path, project_path, project_id, s3_client):
-    """ Puts a file/directory without checking that parent directory exists.
-    """
+    """Puts a file/directory without checking that parent directory exists."""
     if os.path.isdir(local_path):
         _put_directory(local_path, project_path, project_id, s3_client)
     else:
@@ -287,7 +282,7 @@ def _put_recursive(local_path, project_path, project_id, s3_client):
 
 
 def put(local_path, project_path, project_id=None):
-    """ Copy from the local filesystem to the project directory.
+    """Copy from the local filesystem to a project's datasets.
 
     Parameters
     ----------
@@ -367,12 +362,12 @@ def _get_directory(project_path, local_path, project_id, s3_client):
 
 
 def get(project_path, local_path, project_id=None):
-    """ Copy from the project directory to the local filesystem.
+    """Copy from a project's datasets to the local filesystem.
 
     Parameters
     ----------
     project_path : str
-        The source path in the project directory to copy.
+        The source path in the project datasets to copy.
     local_path : str or os.PathLike
         The destination path in the local filesystem.
     project_id : str, optional
@@ -393,14 +388,14 @@ def get(project_path, local_path, project_id=None):
 
 
 def mv(source_path, destination_path, project_id=None):
-    """ Move a file within the project directory.
+    """Move a file within a project's datasets.
 
     Parameters
     ----------
     source_path : str
-        The source path in the project directory to move.
+        The source path in the project datasets to move.
     destination_path : str
-        The destination path in the project directory.
+        The destination path in the project datasets.
     project_id : str, optional
         The project to get files from. You need to have access to this project
         for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
@@ -414,14 +409,14 @@ def mv(source_path, destination_path, project_id=None):
 
 
 def cp(source_path, destination_path, project_id=None, s3_client=None):
-    """ Copy a file within the project directory.
+    """Copy a file within a project's datasets.
 
     Parameters
     ----------
     source_path : str
-        The source path in the project directory to copy.
+        The source path in the project datasets to copy.
     destination_path : str
-        The destination path in the project directory.
+        The destination path in the project datasets.
     project_id : str, optional
         The project to get files from. You need to have access to this project
         for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
@@ -460,12 +455,12 @@ def cp(source_path, destination_path, project_id=None, s3_client=None):
 
 
 def rm(project_path, project_id=None, s3_client=None):
-    """ Remove a file from the project directory.
+    """Remove a file from the project directory.
 
     Parameters
     ----------
     project_path : str
-        The path in the project directory to remove.
+        The path in the project datasets to remove.
     project_id : str, optional
         The project to get files from. You need to have access to this project
         for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
@@ -487,7 +482,7 @@ def rm(project_path, project_id=None, s3_client=None):
 
 
 def rmdir(project_path, project_id=None):
-    """ Remove a directory from the project directory.
+    """Remove a directory from the project datasets.
 
     Parameters
     ----------
@@ -520,12 +515,12 @@ def rmdir(project_path, project_id=None):
 
 
 def etag(project_path, project_id=None):
-    """ Get a unique identifier for the current version of a file.
+    """Get a unique identifier for the current version of a file.
 
     Parameters
     ----------
     project_path : str
-        The path in the project directory.
+        The path in the project datasets.
     project_id : str, optional
         The project to get files from. You need to have access to this project
         for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
@@ -548,8 +543,7 @@ def etag(project_path, project_id=None):
 
 @contextlib.contextmanager
 def open(project_path, mode='r', temp_dir=None, **kwargs):
-    """
-    Open a file from SherlockML filesystem for reading.
+    """Open a file from a project's datasets for reading.
 
     This downloads the file into a temporary directory before opening it, so if
     your files are very large, this function can take a long time.
@@ -557,8 +551,7 @@ def open(project_path, mode='r', temp_dir=None, **kwargs):
     Parameters
     ----------
     project_path : str
-        The path on the SherlockML filesystem. Needs to be a file that exists
-        on the filesystem.
+        The path of the file in the project's datasets to open.
     mode : str
         The opening mode, either 'r' or 'rb'. This is passed down to the
         standard python open function. Writing is currently not supported.
@@ -570,11 +563,14 @@ def open(project_path, mode='r', temp_dir=None, **kwargs):
     """
 
     if _isdir(project_path):
-        raise SherlockMLDatasetsError('Can\'t open a directory.')
+        raise SherlockMLDatasetsError("Can't open directories.")
+
     if any(char in mode for char in ('w', 'a', 'x')):
-        raise NotImplementedError('Currently, only read-mode is implemented.')
+        raise NotImplementedError('Currently, only reading is implemented.')
+
     tmpdir = tempfile.mkdtemp(prefix='.', dir=temp_dir)
     local_path = os.path.join(tmpdir, os.path.basename(project_path))
+
     try:
         local_path = os.path.join(tmpdir, os.path.basename(project_path))
         get(project_path, local_path)

--- a/sherlockml/datasets/__init__.py
+++ b/sherlockml/datasets/__init__.py
@@ -1,0 +1,587 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import fnmatch
+import os
+import posixpath
+import contextlib
+import tempfile
+import io
+
+from botocore.client import ClientError
+
+from sherlockml.datasets import path, session
+from sherlockml.datasets.session import SherlockMLDatasetsError
+
+
+# For backwards compatability
+SherlockMLFileSystemError = SherlockMLDatasetsError
+
+
+def _s3_client(project_id=None):
+    """ Generate a boto S3 client to access this project's SFS directory. """
+
+    # At present, calls to the interface of this module run this function once
+    # to generate an S3 client, then pass it around to avoid making many calls
+    # to the secret service. This could result in an invalid client in the
+    # middle of an operation, if we get unlucky and the AWS credentials expire
+    # at that moment.
+
+    # In the future, we may wish to make a wrapper class that manages the S3
+    # client and proxies calls to its methods. This wrapper would catch
+    # failures resulting from invalid AWS credentials and build a new client
+    # and retry the operation accordingly.
+
+    return session.get().s3_client(project_id)
+
+
+def _bucket(project_id=None):
+    """ Get SFS bucket from Secret Service. """
+    return session.get().bucket(project_id)
+
+
+def ls(prefix='/', project_id=None, show_hidden=False, s3_client=None):
+    """ List contents of project SFS directory.
+
+    Parameters
+    ----------
+    prefix : str, optional
+        List only files in the project directory matching this prefix. Default
+        behaviour is to list all files.
+    project_id : str, optional
+        The project to list files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    show_hidden : bool, optional
+        Include hidden files in the output. Defaults to False.
+    s3_client : botocore.client.S3, optional
+        Advanced - a specific boto client for AWS S3 to use.
+
+    Returns
+    -------
+    list
+        The list of files from the project.
+    """
+
+    if s3_client is None:
+        s3_client = _s3_client(project_id)
+
+    bucket = _bucket(project_id)
+
+    # Use a paginator to enable listing projects with more than 1000 files
+    paginator = s3_client.get_paginator('list_objects_v2')
+    response_iterator = paginator.paginate(
+        Bucket=bucket,
+        Prefix=path.projectpath_to_bucketpath(prefix, project_id)
+    )
+
+    paths = []
+    for part in response_iterator:
+
+        try:
+            objects = part['Contents']
+        except KeyError:
+            continue
+
+        for obj in objects:
+            project_path = path.bucketpath_to_projectpath(obj['Key'])
+
+            # Ignore the root of the project directory
+            if project_path != '/':
+                paths.append(project_path)
+
+    if show_hidden:
+        return paths
+    else:
+        non_hidden_paths = [
+            path_ for path_ in paths
+            if not any(
+                [element.startswith('.') for element in path_.split('/')]
+            )
+        ]
+        return non_hidden_paths
+
+
+def glob(pattern, prefix='/', project_id=None, show_hidden=False,
+         s3_client=None):
+    """
+    List contents of project SFS directory that match
+    a glob pattern.
+
+    Parameters
+    ----------
+    pattern : str
+        The pattern that contents need to match.
+    prefix : str, optional
+        List only files in the project directory that have
+        this prefix. Default behaviour is to list all files.
+    project_id : str, optional
+        The project to list files from. You need to have access
+        to this project for it to work. Defaults to the project
+        set by SHERLOCK_PROJECT_ID in your environment.
+    show_hidden : bool, optional
+        Include hidden files in the output. Defaults to False.
+    s3_client : botocore.client.S3, optional
+        Advanced - a specific boto client for AWS S3 to use.
+
+    Returns
+    -------
+    list
+        The list of files from the project that match
+        the glob pattern.
+    """
+
+    contents = ls(prefix=prefix, project_id=project_id,
+                  show_hidden=show_hidden, s3_client=s3_client)
+
+    return fnmatch.filter(contents, pattern)
+
+
+def _isdir(project_path, project_id=None, s3_client=None):
+    """ Determine if a path in the project directory is a directory.
+
+    Parameters
+    ----------
+    project_path : str
+        The path in the project directory to test.
+    project_id : str, optional
+        The project to list files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    s3_client : botocore.client.S3, optional
+        Advanced - a specific boto client for AWS S3 to use.
+
+    Returns
+    -------
+    bool
+    """
+    # 'Directories' in the S3 bucket always end in a '/'
+    if not project_path.endswith('/'):
+        project_path += '/'
+    matches = ls(
+        project_path,
+        project_id=project_id,
+        show_hidden=True,
+        s3_client=s3_client
+    )
+    return len(matches) >= 1
+
+
+def _isfile(project_path, project_id=None, s3_client=None):
+    """ Determine if a path in the project directory is a file.
+
+    Parameters
+    ----------
+    project_path : str
+        The path in the project directory to test.
+    project_id : str, optional
+        The project to list files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    s3_client : botocore.client.S3, optional
+        Advanced - a specific boto client for AWS S3 to use.
+
+    Returns
+    -------
+    bool
+    """
+    if _isdir(project_path, project_id, s3_client):
+        return False
+    matches = ls(
+        project_path,
+        project_id=project_id,
+        show_hidden=True,
+        s3_client=s3_client
+    )
+    rationalised_path = path.rationalise_projectpath(project_path)
+    return any([match == rationalised_path for match in matches])
+
+
+def _create_parent_directories(project_path, project_id, s3_client):
+
+    bucket = _bucket(project_id)
+
+    # Make sure empty objects exist for directories
+    # List once for speed
+    all_objects = set(
+        ls('/', project_id=project_id, show_hidden=True, s3_client=s3_client)
+    )
+
+    for dirname in path.project_parent_directories(project_path):
+
+        if dirname == '/':
+            # Root is not returned by ls
+            continue
+
+        # We're doing this manually instead of using _isdir as _isdir will
+        # return true if '/somedir/myfile' exists, even if '/somedir/' does not
+        if dirname not in all_objects:
+            bucket_path = path.projectpath_to_bucketpath(dirname, project_id)
+            # Directories on S3 are empty objects with trailing '/' on the key
+            s3_client.put_object(Bucket=bucket,
+                                 Key=bucket_path,
+                                 ServerSideEncryption='AES256')
+
+
+def _put_file(local_path, project_path, project_id, s3_client):
+
+    bucket = _bucket(project_id)
+    bucket_path = path.projectpath_to_bucketpath(project_path, project_id)
+
+    if bucket_path.endswith('/'):
+        msg = ('the destination path {} indicates a directory but the '
+               'source path {} is a normal file - please provide a full '
+               'destination path').format(repr(project_path),
+                                          repr(local_path))
+        raise SherlockMLDatasetsError(msg)
+
+    s3_client.upload_file(
+        local_path,
+        bucket,
+        bucket_path,
+        ExtraArgs={'ServerSideEncryption': 'AES256'}
+    )
+
+
+def _put_directory(local_path, project_path, project_id, s3_client):
+
+    bucket = _bucket(project_id)
+    bucket_path = path.projectpath_to_bucketpath(project_path, project_id)
+
+    # Directories on S3 are empty objects with trailing '/' on the key
+    if not bucket_path.endswith('/'):
+        bucket_path += '/'
+    s3_client.put_object(Bucket=bucket,
+                         Key=bucket_path,
+                         ServerSideEncryption='AES256')
+
+    # Recursively put the contents of the directory
+    for entry in os.listdir(local_path):
+        _put_recursive(
+            os.path.join(local_path, entry),
+            posixpath.join(project_path, entry),
+            project_id,
+            s3_client
+        )
+
+
+def _put_recursive(local_path, project_path, project_id, s3_client):
+    """ Puts a file/directory without checking that parent directory exists.
+    """
+    if os.path.isdir(local_path):
+        _put_directory(local_path, project_path, project_id, s3_client)
+    else:
+        _put_file(local_path, project_path, project_id, s3_client)
+
+
+def put(local_path, project_path, project_id=None):
+    """ Copy from the local filesystem to the project directory.
+
+    Parameters
+    ----------
+    local_path : str or os.PathLike
+        The source path in the local filesystem to copy.
+    project_path : str
+        The destination path in the project directory.
+    project_id : str, optional
+        The project to put files in. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    """
+
+    if hasattr(os, 'fspath'):
+        local_path = os.fspath(local_path)
+
+    s3_client = _s3_client(project_id)
+
+    _create_parent_directories(project_path, project_id, s3_client)
+    _put_recursive(local_path, project_path, project_id, s3_client)
+
+
+def _get_file(project_path, local_path, project_id, s3_client):
+
+    if local_path.endswith('/'):
+        msg = ('the destination path {} indicates a directory but the '
+               'source path {} is a normal file - please provide a full '
+               'destination path').format(repr(project_path),
+                                          repr(local_path))
+        raise SherlockMLDatasetsError(msg)
+
+    bucket = _bucket(project_id)
+    bucket_path = path.projectpath_to_bucketpath(project_path, project_id)
+
+    try:
+        s3_client.download_file(bucket, bucket_path, local_path)
+    except ClientError as err:
+        if '404' in err.args[0]:
+            msg = 'no file {} in project'.format(repr(project_path))
+            raise SherlockMLDatasetsError(msg)
+        else:
+            raise
+
+
+def _get_directory(project_path, local_path, project_id, s3_client):
+
+    # Firstly, make sure that the location to write to locally exists
+    containing_dir = os.path.dirname(local_path)
+    if len(containing_dir) == 0:
+        containing_dir = '.'
+    if not os.path.isdir(containing_dir):
+        msg = 'No such directory: {}'.format(repr(containing_dir))
+        raise IOError(msg)
+
+    paths_to_get = ls(
+        project_path,
+        project_id=project_id,
+        show_hidden=True,
+        s3_client=s3_client
+    )
+    for object_path in paths_to_get:
+
+        local_dest = os.path.join(
+            local_path,
+            path.project_relative_path(project_path, object_path))
+
+        if object_path.endswith('/'):
+            # Objects with a trailing '/' on S3 indicate directories
+            if not os.path.exists(local_dest):
+                os.makedirs(local_dest)
+        else:
+            # Make sure directory exists to put files into
+            dirname = os.path.dirname(local_dest)
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+            _get_file(object_path, local_dest, project_id, s3_client)
+
+
+def get(project_path, local_path, project_id=None):
+    """ Copy from the project directory to the local filesystem.
+
+    Parameters
+    ----------
+    project_path : str
+        The source path in the project directory to copy.
+    local_path : str or os.PathLike
+        The destination path in the local filesystem.
+    project_id : str, optional
+        The project to get files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    """
+
+    if hasattr(os, 'fspath'):
+        local_path = os.fspath(local_path)
+
+    client = _s3_client(project_id)
+
+    if _isdir(project_path, project_id, client):
+        _get_directory(project_path, local_path, project_id, client)
+    else:
+        _get_file(project_path, local_path, project_id, client)
+
+
+def mv(source_path, destination_path, project_id=None):
+    """ Move a file within the project directory.
+
+    Parameters
+    ----------
+    source_path : str
+        The source path in the project directory to move.
+    destination_path : str
+        The destination path in the project directory.
+    project_id : str, optional
+        The project to get files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    """
+
+    s3_client = _s3_client(project_id)
+
+    cp(source_path, destination_path, project_id, s3_client)
+    rm(source_path, project_id, s3_client)
+
+
+def cp(source_path, destination_path, project_id=None, s3_client=None):
+    """ Copy a file within the project directory.
+
+    Parameters
+    ----------
+    source_path : str
+        The source path in the project directory to copy.
+    destination_path : str
+        The destination path in the project directory.
+    project_id : str, optional
+        The project to get files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    s3_client : botocore.client.S3, optional
+        Advanced - a specific boto client for AWS S3 to use.
+    """
+
+    if s3_client is None:
+        s3_client = _s3_client(project_id)
+
+    if not _isfile(source_path, project_id, s3_client):
+        raise SherlockMLDatasetsError('source_path must be a file')
+
+    if destination_path.endswith('/'):
+        raise SherlockMLDatasetsError('destination_path must be a file path')
+
+    bucket = _bucket(project_id)
+    source_bucket_path = path.projectpath_to_bucketpath(
+        source_path, project_id
+    )
+    destination_bucket_path = path.projectpath_to_bucketpath(
+        destination_path, project_id
+    )
+
+    copy_source = {
+        'Bucket': bucket,
+        'Key': source_bucket_path
+    }
+    s3_client.copy(
+        copy_source,
+        bucket,
+        destination_bucket_path,
+        ExtraArgs={'ServerSideEncryption': 'AES256'}
+    )
+
+
+def rm(project_path, project_id=None, s3_client=None):
+    """ Remove a file from the project directory.
+
+    Parameters
+    ----------
+    project_path : str
+        The path in the project directory to remove.
+    project_id : str, optional
+        The project to get files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    s3_client : botocore.client.S3, optional
+        Advanced - a specific boto client for AWS S3 to use.
+    """
+
+    if s3_client is None:
+        s3_client = _s3_client(project_id)
+
+    if not _isfile(project_path, project_id, s3_client):
+        raise SherlockMLDatasetsError('not a file')
+
+    bucket = _bucket(project_id)
+    bucket_path = path.projectpath_to_bucketpath(project_path, project_id)
+
+    s3_client.delete_object(Bucket=bucket, Key=bucket_path)
+
+
+def rmdir(project_path, project_id=None):
+    """ Remove a directory from the project directory.
+
+    Parameters
+    ----------
+    remote_path : str
+        The path of the directory to remove.
+    project_id : str, optional
+        The project to get files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+    """
+
+    s3_client = _s3_client(project_id)
+
+    if not _isdir(project_path, project_id, s3_client):
+        raise SherlockMLDatasetsError('not a directory')
+
+    contents = ls(project_path, project_id, show_hidden=True,
+                  s3_client=s3_client)
+    if not len(contents) == 1:
+        raise SherlockMLDatasetsError('directory is not empty')
+
+    # Directory paths must end with '/'
+    if not project_path.endswith('/'):
+        project_path += '/'
+
+    bucket = _bucket(project_id)
+    bucket_path = path.projectpath_to_bucketpath(project_path, project_id)
+
+    s3_client.delete_object(Bucket=bucket, Key=bucket_path)
+
+
+def etag(project_path, project_id=None):
+    """ Get a unique identifier for the current version of a file.
+
+    Parameters
+    ----------
+    project_path : str
+        The path in the project directory.
+    project_id : str, optional
+        The project to get files from. You need to have access to this project
+        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        your environment.
+
+    Returns
+    -------
+    str
+    """
+
+    client = _s3_client(project_id)
+
+    bucket = _bucket(project_id)
+    bucket_path = path.projectpath_to_bucketpath(project_path, project_id)
+
+    s3_object = client.get_object(Bucket=bucket, Key=bucket_path)
+
+    return s3_object['ETag'].strip('"')
+
+
+@contextlib.contextmanager
+def open(project_path, mode='r', temp_dir=None, **kwargs):
+    """
+    Open a file from SherlockML filesystem for reading.
+
+    This downloads the file into a temporary directory before opening it, so if
+    your files are very large, this function can take a long time.
+
+    Parameters
+    ----------
+    project_path : str
+        The path on the SherlockML filesystem. Needs to be a file that exists
+        on the filesystem.
+    mode : str
+        The opening mode, either 'r' or 'rb'. This is passed down to the
+        standard python open function. Writing is currently not supported.
+    temp_dir : str
+        A directory on the local filesystem where you would like the file to be
+        saved into temporarily. Note that on SherlockML servers, the default
+        temporary directory can break with large files, so if your file is
+        upwards of 2GB, it is recommended to specify temp_dir='/project'.
+    """
+
+    if _isdir(project_path):
+        raise SherlockMLDatasetsError('Can\'t open a directory.')
+    if any(char in mode for char in ('w', 'a', 'x')):
+        raise NotImplementedError('Currently, only read-mode is implemented.')
+    tmpdir = tempfile.mkdtemp(prefix='.', dir=temp_dir)
+    local_path = os.path.join(tmpdir, os.path.basename(project_path))
+    try:
+        local_path = os.path.join(tmpdir, os.path.basename(project_path))
+        get(project_path, local_path)
+        with io.open(local_path, mode, **kwargs) as file_object:
+            yield file_object
+    finally:
+        if os.path.isfile(local_path):
+            os.remove(local_path)
+        if os.path.isdir(tmpdir):
+            os.rmdir(tmpdir)

--- a/sherlockml/datasets/path.py
+++ b/sherlockml/datasets/path.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import posixpath
 
 from sherlockml.datasets import session
@@ -43,7 +42,7 @@ def projectpath_to_bucketpath(project_path, project_id=None):
 
 
 def bucketpath_to_projectpath(path):
-    """ Drop the project ID from the front of the path. """
+    """Drop the project ID from the front of the path."""
     parts = path.split('/')
     return posixpath.join('/', *parts[1:])
 
@@ -67,7 +66,7 @@ def project_relative_path(project_root, project_path):
 
 
 def project_parent_directories(project_path):
-    """ List all the directories in the tree containing this file.
+    """List all the directories in the tree containing this file.
 
     Parameters
     ----------

--- a/sherlockml/datasets/path.py
+++ b/sherlockml/datasets/path.py
@@ -1,0 +1,96 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import posixpath
+
+from sherlockml.datasets import session
+
+
+def rationalise_projectpath(path):
+
+    # All paths should be relative to root
+    path = posixpath.join('/', path)
+
+    normed = posixpath.normpath(path)
+
+    if path.endswith('/') and not normed.endswith('/'):
+        normed += '/'
+
+    return normed
+
+
+def projectpath_to_bucketpath(project_path, project_id=None):
+
+    if project_id is None:
+        project_id = session.project_id_from_environment()
+
+    # Project path will already start with '/' so just prepend the project ID
+    bucket_path = project_id + rationalise_projectpath(project_path)
+
+    return bucket_path
+
+
+def bucketpath_to_projectpath(path):
+    """ Drop the project ID from the front of the path. """
+    parts = path.split('/')
+    return posixpath.join('/', *parts[1:])
+
+
+def project_relative_path(project_root, project_path):
+
+    project_root = rationalise_projectpath(project_root)
+    project_path = rationalise_projectpath(project_path)
+
+    if not project_path.startswith(project_root):
+        tpl = '{} is not a sub path of {}'
+        raise ValueError(tpl.format(project_path, project_root))
+
+    # Remove the root
+    relative_path = project_path[len(project_root):]
+
+    # Get rid of any leading '/'es
+    relative_path = relative_path.lstrip('/')
+
+    return relative_path
+
+
+def project_parent_directories(project_path):
+    """ List all the directories in the tree containing this file.
+
+    Parameters
+    ----------
+    project_path : str
+        The file to list the parent directories of
+
+    Returns
+    -------
+    list of str
+        The paths of the parent directories
+    """
+
+    # Ensure in assumed format - can now assume to be absolute
+    project_path = rationalise_projectpath(project_path)
+
+    # Stripping trailing slashes as if it's a directory we still just want to
+    # get its parent
+    dirname = posixpath.dirname(project_path.rstrip('/'))
+
+    directories = []
+
+    parts = dirname.split('/')
+    for i_last in range(1, len(parts) + 1):
+        directories.append('/'.join(parts[:i_last]) + '/')
+
+    return directories

--- a/sherlockml/datasets/session.py
+++ b/sherlockml/datasets/session.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
 import time
 

--- a/sherlockml/datasets/session.py
+++ b/sherlockml/datasets/session.py
@@ -1,0 +1,100 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import time
+
+import boto3
+
+import sherlockml
+
+
+class SherlockMLDatasetsError(Exception):
+    pass
+
+
+def project_id_from_environment():
+    try:
+        project_id = os.environ['SHERLOCKML_PROJECT_ID']
+    except KeyError:
+        raise SherlockMLDatasetsError(
+            'No SHERLOCKML_PROJECT_ID in environment - set the project ID '
+            'explicitly to use outside of SherlockML'
+        )
+    return project_id
+
+
+SECRETS_CACHE_TTL = 10
+
+
+class DatasetsSession(object):
+
+    def __init__(self):
+        self.secret_client = sherlockml.client('secret')
+        self.bucket_cache = {}
+        self.secrets_cache = {}
+
+    def bucket(self, project_id):
+        if project_id is None:
+            project_id = project_id_from_environment()
+        if project_id not in self.bucket_cache:
+            secrets = self.secret_client.datasets_secrets(project_id)
+            self.bucket_cache[project_id] = secrets.bucket
+        return self.bucket_cache[project_id]
+
+    def _get_verified_secrets(self, project_id):
+        secrets = self.secret_client.datasets_secrets(project_id)
+        tries = 1
+        while not secrets.verified:
+            if tries >= 30:
+                raise ValueError('Secrets not verified after 60 seconds')
+            time.sleep(2)
+            secrets = self.secret_client.datasets_secrets(project_id)
+            tries += 1
+        return secrets
+
+    def _cached_secrets(self, project_id):
+        if (
+            project_id not in self.secrets_cache or
+            self.secrets_cache[project_id][1] + SECRETS_CACHE_TTL < time.time()
+        ):
+            secrets = self._get_verified_secrets(project_id)
+            self.secrets_cache[project_id] = secrets, time.time()
+        return self.secrets_cache[project_id][0]
+
+    def s3_client(self, project_id=None):
+
+        if project_id is None:
+            project_id = project_id_from_environment()
+
+        secrets = self._cached_secrets(project_id)
+
+        boto_session = boto3.session.Session(
+            aws_access_key_id=secrets.access_key,
+            aws_secret_access_key=secrets.secret_key,
+            region_name='eu-west-1'
+        )
+
+        return boto_session.client('s3')
+
+
+DATASETS_SESSION = None
+
+
+def get():
+    global DATASETS_SESSION
+    if DATASETS_SESSION is None:
+        DATASETS_SESSION = DatasetsSession()
+    return DATASETS_SESSION

--- a/sherlockml/filesystem.py
+++ b/sherlockml/filesystem.py
@@ -1,0 +1,24 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from warnings import warn as _warn
+
+_WARNING_MESSAGE = (
+    'sherlockml.filesystem has been renamed sherlockml.datasets - please '
+    'update your code to use the new import location'
+)
+_warn(_WARNING_MESSAGE)
+
+from sherlockml.datasets import *  # noqa: F401, F403

--- a/sherlockml/filesystem.py
+++ b/sherlockml/filesystem.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from warnings import warn as _warn
 
 _WARNING_MESSAGE = (

--- a/sherlockml/filesystem.py
+++ b/sherlockml/filesystem.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from warnings import warn as _warn
+import warnings
 
 _WARNING_MESSAGE = (
     'sherlockml.filesystem has been renamed sherlockml.datasets - please '
     'update your code to use the new import location'
 )
-_warn(_WARNING_MESSAGE)
+warnings.warn(_WARNING_MESSAGE)
 
 from sherlockml.datasets import *  # noqa: F401, F403

--- a/tests/clients/test_secret.py
+++ b/tests/clients/test_secret.py
@@ -1,0 +1,43 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from marshmallow import ValidationError
+
+from sherlockml.clients.secret import DatasetsSecrets, DatasetsSecretsSchema
+
+
+TEST_SECRETS = DatasetsSecrets(
+    bucket='test-bucket',
+    access_key='test-access-key',
+    secret_key='test-secret-key',
+    verified=True
+)
+
+TEST_SECRETS_BODY = {
+    'bucket': TEST_SECRETS.bucket,
+    'access_key': TEST_SECRETS.access_key,
+    'secret_key': TEST_SECRETS.secret_key,
+    'verified': TEST_SECRETS.verified
+}
+
+
+def test_datasets_secrets_schema():
+    assert DatasetsSecretsSchema().load(TEST_SECRETS_BODY) == TEST_SECRETS
+
+
+def test_datasets_secrets_invalid():
+    with pytest.raises(ValidationError):
+        DatasetsSecretsSchema().load({})

--- a/tests/datasets/fixtures.py
+++ b/tests/datasets/fixtures.py
@@ -77,10 +77,9 @@ def _test_secrets():
 
 @pytest.fixture
 def mock_secret_client(mocker):
-    mocker.patch(
-        'sherlockml.clients.secret.SecretClient.datasets_secrets',
-        return_value=_test_secrets()
-    )
+    mock_client = mocker.Mock()
+    mock_client.datasets_secrets.return_value = _test_secrets()
+    mocker.patch('sherlockml.client', return_value=mock_client)
 
 
 @pytest.fixture

--- a/tests/datasets/fixtures.py
+++ b/tests/datasets/fixtures.py
@@ -122,20 +122,20 @@ def remote_tree(request, project_directory):
     return TEST_TREE
 
 
-_s3_client_cache = None
+_S3_CLIENT_CACHE = None
 
 
 def _s3_client():
-    global _s3_client_cache
-    if _s3_client_cache is None:
+    global _S3_CLIENT_CACHE
+    if _S3_CLIENT_CACHE is None:
         secrets = _test_secrets()
         boto_session = boto3.session.Session(
             aws_access_key_id=secrets.access_key,
             aws_secret_access_key=secrets.secret_key,
             region_name='eu-west-1'
         )
-        _s3_client_cache = boto_session.client('s3')
-    return _s3_client_cache
+        _S3_CLIENT_CACHE = boto_session.client('s3')
+    return _S3_CLIENT_CACHE
 
 
 def _path_in_bucket(path):

--- a/tests/datasets/fixtures.py
+++ b/tests/datasets/fixtures.py
@@ -1,0 +1,226 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import posixpath
+from contextlib import contextmanager
+import tempfile
+import shutil
+import uuid
+
+import boto3
+import pytest
+
+from sherlockml.clients.secret import DatasetsSecrets
+
+TEST_BUCKET_NAME = 'sml-sfs-test'
+
+TEST_FILE_NAME = 'test_file'
+TEST_FILE_CONTENT = b'this is a test file'
+TEST_FILE_CONTENT_CHANGED = b'this is a different test file'
+TEST_TREE = ['input/',
+             'input/dir1/',
+             'input/dir1/file1',
+             'input/dir1/.file2',
+             'input/.dir2/',
+             'input/.dir2/file3',
+             'output/',
+             'output/file4',
+             'empty/']
+TEST_TREE_NO_HIDDEN_FILES = ['input/',
+                             'input/dir1/',
+                             'input/dir1/file1',
+                             'output/',
+                             'output/file4',
+                             'empty/']
+VALID_ROOT_PATHS = ['', './', '/']
+VALID_DIRECTORIES = ['input', 'input/', './input', './input/', '/input',
+                     '/input/', '/input/dir1/', '/input/.dir2']
+VALID_FILES = [
+    'input/dir1/file1', './input/dir1/file1', '/input/dir1/file1',
+    'input/.dir2/file3'
+]
+EMPTY_DIRECTORY = 'empty/'
+INVALID_PATHS = ['inp', 'inp/', './inp', './inp/', '/inp', '/inp/',
+                 'input/dir1/fil', './input/dir1/fil', '/input/dir1/fil',
+                 'input/dir1/file1/', './input/dir1/file1/',
+                 '/input/dir1/file1/']
+TEST_DIRECTORY = 'test_directory'
+TEST_NON_EXISTENT = 'test_non_existent'
+
+
+@pytest.fixture
+def project_env(monkeypatch):
+    monkeypatch.setenv('SHERLOCKML_PROJECT_ID', str(uuid.uuid4()))
+
+
+def _test_secrets():
+    return DatasetsSecrets(
+        bucket=TEST_BUCKET_NAME,
+        access_key=os.environ['AWS_ACCESS_KEY_ID'],
+        secret_key=os.environ['AWS_SECRET_ACCESS_KEY'],
+        verified=True
+    )
+
+
+@pytest.fixture
+def mock_secret_client(mocker):
+    mocker.patch(
+        'sherlockml.clients.secret.SecretClient.datasets_secrets',
+        return_value=_test_secrets()
+    )
+
+
+@pytest.fixture
+def project_directory(request, mock_secret_client, project_env):
+
+    project_id = os.environ['SHERLOCKML_PROJECT_ID']
+
+    # Make the empty directory
+    _make_file(request, '')
+    yield
+
+    # Tear down
+    client = _s3_client()
+    response = client.list_objects_v2(
+        Bucket=TEST_BUCKET_NAME,
+        Prefix=project_id
+    )
+    objects = [{'Key': obj['Key']} for obj in response['Contents']]
+    client.delete_objects(
+        Bucket=TEST_BUCKET_NAME,
+        Delete={'Objects': objects}
+    )
+
+
+@pytest.fixture
+def remote_file(request, project_directory):
+    _make_file(request, TEST_FILE_NAME, TEST_FILE_CONTENT)
+    return TEST_FILE_NAME
+
+
+@pytest.fixture
+def remote_tree(request, project_directory):
+    for path in TEST_TREE:
+        if path.endswith('/'):
+            # Just touch, is a directory
+            _make_file(request, path)
+        else:
+            # Add test file content
+            _make_file(request, path, TEST_FILE_CONTENT)
+    return TEST_TREE
+
+
+_s3_client_cache = None
+
+
+def _s3_client():
+    global _s3_client_cache
+    if _s3_client_cache is None:
+        secrets = _test_secrets()
+        boto_session = boto3.session.Session(
+            aws_access_key_id=secrets.access_key,
+            aws_secret_access_key=secrets.secret_key,
+            region_name='eu-west-1'
+        )
+        _s3_client_cache = boto_session.client('s3')
+    return _s3_client_cache
+
+
+def _path_in_bucket(path):
+    project_id = os.environ['SHERLOCKML_PROJECT_ID']
+    combined = posixpath.join(project_id, path.lstrip('/'))
+    if path.endswith('/'):
+        return posixpath.normpath(combined) + '/'
+    else:
+        return posixpath.normpath(combined)
+
+
+def write_remote_object(path, content):
+    client = _s3_client()
+    client.put_object(
+        Bucket=TEST_BUCKET_NAME,
+        Key=_path_in_bucket(path),
+        Body=content,
+        ServerSideEncryption='AES256'
+    )
+
+
+def read_remote_object(path):
+    client = _s3_client()
+    obj = client.get_object(
+        Bucket=TEST_BUCKET_NAME,
+        Key=_path_in_bucket(path)
+    )
+    return obj['Body'].read()
+
+
+def _make_file(request, path, content=''):
+    write_remote_object(path, content)
+
+    def tear_down():
+        _s3_client().delete_object(
+            Bucket=TEST_BUCKET_NAME,
+            Key=_path_in_bucket(path)
+        )
+
+    request.addfinalizer(tear_down)
+
+
+@pytest.fixture
+def local_file():
+    with tempfile.NamedTemporaryFile(mode='wb') as f:
+        f.write(TEST_FILE_CONTENT)
+        f.flush()
+        yield f.name
+
+
+@pytest.fixture
+def local_file_changed():
+    with tempfile.NamedTemporaryFile(mode='wb') as f:
+        f.write(TEST_FILE_CONTENT_CHANGED)
+        f.flush()
+        yield f.name
+
+
+@contextmanager
+def temporary_directory():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def local_tree():
+
+    with temporary_directory() as temp_dir:
+
+        for tree_path in TEST_TREE:
+
+            path = os.path.join(temp_dir, tree_path)
+
+            if tree_path.endswith('/'):
+                if not os.path.exists(path):
+                    os.makedirs(path)
+            else:
+                dirname = os.path.dirname(path)
+                if not os.path.exists(dirname):
+                    os.makedirs(dirname)
+                with open(path, 'wb') as fp:
+                    fp.write(TEST_FILE_CONTENT)
+
+        yield temp_dir

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -50,7 +50,7 @@ pytestmark = pytest.mark.usefixtures('project_directory')
 
 
 @pytest.mark.parametrize(  # noqa: F811
-    'path,show_hidden,expected',
+    'path, show_hidden, expected',
     [(path, True, TEST_TREE) for path in VALID_ROOT_PATHS] +
     [(path, False, TEST_TREE_NO_HIDDEN_FILES) for path in VALID_ROOT_PATHS]
 )
@@ -62,7 +62,7 @@ def test_ls_root(remote_tree, path, show_hidden, expected):
 
 
 @pytest.mark.parametrize(  # noqa: F811
-    'prefix,show_hidden,expected',
+    'prefix, show_hidden, expected',
     [(directory, True, TEST_TREE) for directory in VALID_DIRECTORIES] +
     [(directory, False, TEST_TREE_NO_HIDDEN_FILES)
      for directory in VALID_DIRECTORIES]
@@ -76,7 +76,7 @@ def test_ls_subdirectory(remote_tree, prefix, show_hidden, expected):
 
 
 @pytest.mark.parametrize(  # noqa: F811
-    'pattern,prefix,show_hidden,expected',
+    'pattern, prefix, show_hidden, expected',
     [('*dir2*', directory, True, TEST_TREE)
      for directory in VALID_DIRECTORIES] +
     [('*file1', directory, False, TEST_TREE_NO_HIDDEN_FILES)
@@ -94,7 +94,7 @@ def test_glob(pattern, remote_tree, prefix, show_hidden, expected):
 
 
 @pytest.mark.parametrize(  # noqa: F811
-    'path,result',
+    'path, result',
     [(path, True) for path in VALID_DIRECTORIES] +
     [(path, False) for path in VALID_FILES + INVALID_PATHS])
 def test_isdir(remote_tree, path, result):
@@ -102,7 +102,7 @@ def test_isdir(remote_tree, path, result):
 
 
 @pytest.mark.parametrize(  # noqa: F811
-    'path,result',
+    'path, result',
     [(path, True) for path in VALID_FILES] +
     [(path, False) for path in VALID_DIRECTORIES + INVALID_PATHS])
 def test_isfile(remote_tree, path, result):
@@ -140,7 +140,7 @@ def test_put_file_in_directory(local_file, destination):
         datasets.put(local_file, destination)
 
 
-@pytest.mark.parametrize('destination,resolved_destination', [  # noqa: F811
+@pytest.mark.parametrize('destination, resolved_destination', [  # noqa: F811
     ('', ''),
     ('./', ''),
     ('/', ''),
@@ -259,7 +259,7 @@ def test_mv(remote_file, destination):
     assert content == TEST_FILE_CONTENT
 
 
-@pytest.mark.parametrize('remote_dir,destination', [
+@pytest.mark.parametrize('remote_dir, destination', [
     ('/input/', '/output/')
 ])
 def test_mv_directory_source(remote_dir, destination):
@@ -282,7 +282,7 @@ def test_cp(remote_file, destination):
     assert destination_content == source_content
 
 
-@pytest.mark.parametrize('remote_dir,destination', [
+@pytest.mark.parametrize('remote_dir, destination', [
     ('/input/no-such-file', '/output/new-file'),
     ('/input/', '/output/')
 ])

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -55,8 +55,10 @@ pytestmark = pytest.mark.usefixtures('project_directory')
     [(path, False, TEST_TREE_NO_HIDDEN_FILES) for path in VALID_ROOT_PATHS]
 )
 def test_ls_root(remote_tree, path, show_hidden, expected):
-    assert set(datasets.ls(path, show_hidden=show_hidden)) == set(
-        '/' + path for path in expected)
+    assert (
+        set(datasets.ls(path, show_hidden=show_hidden)) ==
+        {'/' + path for path in expected}
+    )
 
 
 @pytest.mark.parametrize(  # noqa: F811

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1,0 +1,362 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import fnmatch
+import os
+import posixpath
+import pytest
+
+import sherlockml.datasets as sfs
+
+from tests.datasets.fixtures import (  # noqa: F401
+    mock_secret_client,
+    project_env,
+    project_directory,
+    write_remote_object,
+    read_remote_object,
+    remote_file,
+    remote_tree,
+    local_file,
+    local_file_changed,
+    local_tree,
+    temporary_directory,
+    TEST_DIRECTORY,
+    TEST_FILE_NAME,
+    TEST_TREE,
+    TEST_TREE_NO_HIDDEN_FILES,
+    VALID_ROOT_PATHS,
+    VALID_DIRECTORIES,
+    VALID_FILES,
+    INVALID_PATHS,
+    TEST_FILE_CONTENT,
+    TEST_NON_EXISTENT,
+    EMPTY_DIRECTORY
+)
+
+
+pytestmark = pytest.mark.usefixtures('project_directory')
+
+
+@pytest.mark.parametrize(  # noqa: F811
+    'path,show_hidden,expected',
+    [(path, True, TEST_TREE) for path in VALID_ROOT_PATHS] +
+    [(path, False, TEST_TREE_NO_HIDDEN_FILES) for path in VALID_ROOT_PATHS]
+)
+def test_ls_root(remote_tree, path, show_hidden, expected):
+    assert set(sfs.ls(path, show_hidden=show_hidden)) == set(
+        '/' + path for path in expected)
+
+
+@pytest.mark.parametrize(  # noqa: F811
+    'prefix,show_hidden,expected',
+    [(directory, True, TEST_TREE) for directory in VALID_DIRECTORIES] +
+    [(directory, False, TEST_TREE_NO_HIDDEN_FILES)
+     for directory in VALID_DIRECTORIES]
+)
+def test_ls_subdirectory(remote_tree, prefix, show_hidden, expected):
+    if prefix.startswith('./'):
+        prefix = prefix[2:]
+    prefix = prefix.lstrip('/')
+    matches = ['/' + path for path in expected if path.startswith(prefix)]
+    assert set(sfs.ls(prefix, show_hidden=show_hidden)) == set(matches)
+
+
+@pytest.mark.parametrize(  # noqa: F811
+    'pattern,prefix,show_hidden,expected',
+    [('*dir2*', directory, True, TEST_TREE)
+     for directory in VALID_DIRECTORIES] +
+    [('*file1', directory, False, TEST_TREE_NO_HIDDEN_FILES)
+     for directory in VALID_DIRECTORIES]
+)
+def test_glob(pattern, remote_tree, prefix, show_hidden, expected):
+    if prefix.startswith('./'):
+        prefix = prefix[2:]
+    prefix = prefix.lstrip('/')
+    matches = ['/' + path for path in expected
+               if path.startswith(prefix) and fnmatch.fnmatch(path, pattern)]
+    assert set(sfs.glob(pattern, prefix,
+                        show_hidden=show_hidden)) == set(matches)
+
+
+@pytest.mark.parametrize(  # noqa: F811
+    'path,result',
+    [(path, True) for path in VALID_DIRECTORIES] +
+    [(path, False) for path in VALID_FILES + INVALID_PATHS])
+def test_isdir(remote_tree, path, result):
+    assert sfs._isdir(path) is result
+
+
+@pytest.mark.parametrize(  # noqa: F811
+    'path,result',
+    [(path, True) for path in VALID_FILES] +
+    [(path, False) for path in VALID_DIRECTORIES + INVALID_PATHS])
+def test_isfile(remote_tree, path, result):
+    assert sfs._isfile(path) is result
+
+
+@pytest.mark.parametrize('destination', [  # noqa: F811
+    TEST_FILE_NAME,
+    '/' + TEST_FILE_NAME,
+    './' + TEST_FILE_NAME
+])
+def test_put_file(local_file, destination):
+    sfs.put(local_file, destination)
+    content = read_remote_object(TEST_FILE_NAME)
+    assert content == TEST_FILE_CONTENT
+
+
+def test_put_file_nonexistent_directory(local_file):  # noqa: F811
+    sfs.put(local_file, '/path/to/newdir/test_file')
+    for path in ['/path/', '/path/to/', '/path/to/newdir/']:
+        content = read_remote_object(path)
+        assert content == b''
+    content = read_remote_object('/path/to/newdir/test_file')
+    assert content == TEST_FILE_CONTENT
+
+
+@pytest.mark.parametrize('destination', [  # noqa: F811
+    '', './', '/',
+    TEST_DIRECTORY + '/',
+    './' + TEST_DIRECTORY + '/',
+    '/' + TEST_DIRECTORY + '/'
+])
+def test_put_file_in_directory(local_file, destination):
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.put(local_file, destination)
+
+
+@pytest.mark.parametrize('destination,resolved_destination', [  # noqa: F811
+    ('', ''),
+    ('./', ''),
+    ('/', ''),
+    (TEST_DIRECTORY, TEST_DIRECTORY),
+    ('./' + TEST_DIRECTORY, TEST_DIRECTORY),
+    ('/' + TEST_DIRECTORY, TEST_DIRECTORY),
+    (TEST_DIRECTORY + '/', TEST_DIRECTORY),
+    ('./' + TEST_DIRECTORY + '/', TEST_DIRECTORY),
+    ('/' + TEST_DIRECTORY + '/', TEST_DIRECTORY)
+])
+def test_put_tree(local_tree, destination, resolved_destination):
+    sfs.put(local_tree, destination)
+    for filename in TEST_TREE:
+        path = posixpath.join(resolved_destination, filename)
+        content = read_remote_object(path)
+        if filename.endswith('/'):
+            assert content == b''
+        else:
+            assert content == TEST_FILE_CONTENT
+
+
+def test_get_file(remote_file):  # noqa: F811
+    with temporary_directory() as dirname:
+        path = os.path.join(dirname, TEST_FILE_NAME)
+        sfs.get(remote_file, path)
+        with open(path, 'rb') as f:
+            content = f.read()
+    assert content == TEST_FILE_CONTENT
+
+
+def test_get_file_in_directory(remote_file):  # noqa: F811
+    with temporary_directory() as dirname:
+        # Ensure dirname ends with exactly one '/'
+        dirname = dirname.rstrip('/') + '/'
+        with pytest.raises(sfs.SherlockMLFileSystemError):
+            sfs.get(remote_file, dirname)
+
+
+def test_get_file_bad_local_path(remote_file):  # noqa: F811
+    with temporary_directory() as dirname:
+        path = os.path.join(dirname, 'directory/does/not/exist')
+        with pytest.raises(IOError):
+            sfs.get(remote_file, path)
+
+
+def _validate_local_tree(root, tree):
+    for path in tree:
+        full_path = os.path.join(root, path)
+        if full_path.endswith('/'):
+            assert os.path.isdir(full_path)
+        else:
+            with open(full_path, 'rb') as f:
+                content = f.read()
+            assert content == TEST_FILE_CONTENT
+
+
+@pytest.mark.parametrize('path', VALID_ROOT_PATHS)  # noqa: F811
+def test_get_tree(remote_tree, path):
+    with temporary_directory() as dirname:
+        sfs.get(path, dirname)
+        _validate_local_tree(dirname, TEST_TREE)
+
+
+@pytest.mark.parametrize('path', VALID_ROOT_PATHS)  # noqa: F811
+def test_get_tree_in_directory(remote_tree, path):
+    with temporary_directory() as dirname:
+        # Ensure dirname ends with exactly one '/'
+        dirname = dirname.rstrip('/') + '/'
+        sfs.get(path, dirname)
+        _validate_local_tree(dirname, TEST_TREE)
+
+
+@pytest.mark.parametrize('path', VALID_DIRECTORIES)  # noqa: F811
+def test_get_subtree(remote_tree, path):
+    prefix = path.strip('/') + '/'
+    subtree = [tree_path[len(prefix):] for tree_path in TEST_TREE
+               if tree_path.startswith(prefix)]
+    with temporary_directory() as dirname:
+        sfs.get(path, dirname)
+        _validate_local_tree(dirname, subtree)
+
+
+@pytest.mark.parametrize('path', VALID_DIRECTORIES)  # noqa: F811
+def test_get_subtree_in_directory(remote_tree, path):
+    prefix = path.strip('/') + '/'
+    subtree = [tree_path[len(prefix):] for tree_path in TEST_TREE
+               if tree_path.startswith(prefix)]
+    with temporary_directory() as dirname:
+        # Ensure dirname ends with exactly one '/'
+        dirname = dirname.rstrip('/') + '/'
+        sfs.get(path, dirname)
+        _validate_local_tree(dirname, subtree)
+
+
+@pytest.mark.parametrize('path', VALID_DIRECTORIES)  # noqa: F811
+def test_get_tree_bad_local_path(remote_tree, path):
+    with temporary_directory() as dirname:
+        local_path = os.path.join(dirname, 'directory/does/not/exist/')
+        with pytest.raises(IOError):
+            sfs.get(path, local_path)
+
+
+def test_get_non_existent():
+    with temporary_directory() as dirname:
+        with pytest.raises(sfs.SherlockMLFileSystemError):
+            sfs.get(TEST_NON_EXISTENT,
+                    os.path.join(dirname, TEST_NON_EXISTENT))
+
+
+@pytest.mark.parametrize('destination', ['new_file'])  # noqa: F811
+def test_mv(remote_file, destination):
+    sfs.mv(remote_file, destination)
+    content = read_remote_object(destination)
+    assert '/' + destination in sfs.ls()
+    assert '/' + remote_file not in sfs.ls()
+    assert content == TEST_FILE_CONTENT
+
+
+@pytest.mark.parametrize('remote_dir,destination', [
+    ('/input/', '/output/')
+])
+def test_mv_directory_source(remote_dir, destination):
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.mv(remote_dir, destination)
+
+
+@pytest.mark.parametrize('destination', ['/output/'])  # noqa: F811
+def test_mv_directory_destination(remote_file, destination):
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.mv(remote_file, destination)
+
+
+@pytest.mark.parametrize('destination', ['new_file'])  # noqa: F811
+def test_cp(remote_file, destination):
+    sfs.cp(remote_file, destination)
+    destination_content = read_remote_object(destination)
+    source_content = read_remote_object(remote_file)
+    assert '/' + destination in sfs.ls()
+    assert destination_content == source_content
+
+
+@pytest.mark.parametrize('remote_dir,destination', [
+    ('/input/no-such-file', '/output/new-file'),
+    ('/input/', '/output/')
+])
+def test_cp_directory_source(remote_dir, destination):
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.cp(remote_dir, destination)
+
+
+@pytest.mark.parametrize('destination', ['/output/'])  # noqa: F811
+def test_cp_directory_destination(remote_file, destination):
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.cp(remote_file, destination)
+
+
+def test_rm(remote_file):  # noqa: F811
+    assert '/' + remote_file in sfs.ls()
+    sfs.rm(remote_file)
+    assert '/' + remote_file not in sfs.ls()
+
+
+@pytest.mark.parametrize('remote_dir', ['/input/', '/input/no-such-file'])
+def test_rm_directory_source(remote_dir):
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.rm(remote_dir)
+
+
+def test_rmdir(remote_tree):  # noqa: F811
+    assert '/' + EMPTY_DIRECTORY in sfs.ls()
+    sfs.rmdir(EMPTY_DIRECTORY)
+    assert '/' + EMPTY_DIRECTORY not in sfs.ls()
+
+
+def test_rmdir_missing():
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.rmdir('missing/directory')
+
+
+def test_rmdir_filetype(remote_tree):  # noqa: F811
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.rmdir(VALID_FILES[0])
+
+
+def test_rmdir_nonempty(remote_tree):  # noqa: F811
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        sfs.rmdir('input/')
+
+
+def test_etag(remote_file):  # noqa: F811
+    etag = sfs.etag(remote_file)
+    assert isinstance(etag, str)
+    assert len(etag) > 0
+
+
+def test_etag_change(remote_file, local_file_changed):  # noqa: F811
+    initial_etag = sfs.etag(remote_file)
+    sfs.put(local_file_changed, remote_file)
+    final_etag = sfs.etag(remote_file)
+    assert final_etag != initial_etag
+
+
+def test_open_read(remote_file):  # noqa: F811
+    with sfs.open(remote_file, 'rb') as fp:
+        assert fp.read() == TEST_FILE_CONTENT
+
+
+def test_open_defaultmode(remote_file):  # noqa: F811
+    with sfs.open(remote_file) as fp:
+        assert fp.read() == TEST_FILE_CONTENT.decode('utf-8')
+
+
+def test_open_missing():
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        with sfs.open('missing/file', 'r'):
+            pass
+
+
+def test_open_directory(remote_tree):  # noqa: F811
+    with pytest.raises(sfs.SherlockMLFileSystemError):
+        with sfs.open('/input', 'r'):
+            pass

--- a/tests/datasets/test_paths.py
+++ b/tests/datasets/test_paths.py
@@ -17,7 +17,7 @@ import pytest
 from sherlockml.datasets import path
 
 
-@pytest.mark.parametrize('path,rationalised_path', [
+@pytest.mark.parametrize('path, rationalised_path', [
     ('', '/'),
     ('./', '/'),
     ('/', '/'),
@@ -32,7 +32,7 @@ def test_rationalise_projectpath(path, rationalised_path):
     assert path.rationalise_projectpath(path) == rationalised_path
 
 
-@pytest.mark.parametrize('project_path,project_id,bucket_path', [
+@pytest.mark.parametrize('project_path, project_id, bucket_path', [
     ('', 'id', 'id/'),
     ('./', 'id', 'id/'),
     ('/', 'id', 'id/'),
@@ -48,7 +48,7 @@ def test_projectpath_to_bucketpath(project_path, project_id, bucket_path):
     assert result == bucket_path
 
 
-@pytest.mark.parametrize('bucket_path,project_path', [
+@pytest.mark.parametrize('bucket_path, project_path', [
     ('id/', '/'),
     ('id/path', '/path'),
     ('id/path/', '/path/'),

--- a/tests/datasets/test_paths.py
+++ b/tests/datasets/test_paths.py
@@ -1,0 +1,74 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from sherlockml.datasets import path
+
+
+@pytest.mark.parametrize('input,output', [
+    ('', '/'),
+    ('./', '/'),
+    ('/', '/'),
+    ('path', '/path'),
+    ('./path', '/path'),
+    ('/path', '/path'),
+    ('path/', '/path/'),
+    ('./path/', '/path/'),
+    ('/path/', '/path/')
+])
+def test_rationalise_projectpath(input, output):
+    assert path.rationalise_projectpath(input) == output
+
+
+@pytest.mark.parametrize('project_path,project_id,bucket_path', [
+    ('', 'id', 'id/'),
+    ('./', 'id', 'id/'),
+    ('/', 'id', 'id/'),
+    ('path', 'id', 'id/path'),
+    ('./path', 'id', 'id/path'),
+    ('/path', 'id', 'id/path'),
+    ('path/', 'id', 'id/path/'),
+    ('./path/', 'id', 'id/path/'),
+    ('/path/', 'id', 'id/path/')
+])
+def test_projectpath_to_bucketpath(project_path, project_id, bucket_path):
+    result = path.projectpath_to_bucketpath(project_path, project_id)
+    assert result == bucket_path
+
+
+@pytest.mark.parametrize('bucket_path,project_path', [
+    ('id/', '/'),
+    ('id/path', '/path'),
+    ('id/path/', '/path/'),
+    ('id/nested/path', '/nested/path')
+])
+def test_bucketpath_to_projectpath(bucket_path, project_path):
+    result = path.bucketpath_to_projectpath(bucket_path)
+    assert result == project_path
+
+
+@pytest.mark.parametrize('project_path', [
+    'input/path/to/somefile.csv',
+    './input/path/to/somefile.csv',
+    '/input/path/to/somefile.csv',
+    'input/path/to/somedir/',
+    './input/path/to/somedir/',
+    '/input/path/to/somedir/'
+])
+def test_project_parent_directories(project_path):
+    correct = ['/', '/input/', '/input/path/', '/input/path/to/']
+    result = path.project_parent_directories(project_path)
+    assert set(result) == set(correct)

--- a/tests/datasets/test_paths.py
+++ b/tests/datasets/test_paths.py
@@ -17,7 +17,7 @@ import pytest
 from sherlockml.datasets import path
 
 
-@pytest.mark.parametrize('path, rationalised_path', [
+@pytest.mark.parametrize('input_path, rationalised_path', [
     ('', '/'),
     ('./', '/'),
     ('/', '/'),
@@ -28,8 +28,8 @@ from sherlockml.datasets import path
     ('./path/', '/path/'),
     ('/path/', '/path/')
 ])
-def test_rationalise_projectpath(path, rationalised_path):
-    assert path.rationalise_projectpath(path) == rationalised_path
+def test_rationalise_projectpath(input_path, rationalised_path):
+    assert path.rationalise_projectpath(input_path) == rationalised_path
 
 
 @pytest.mark.parametrize('project_path, project_id, bucket_path', [

--- a/tests/datasets/test_paths.py
+++ b/tests/datasets/test_paths.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import pytest
 
 from sherlockml.datasets import path
 
 
-@pytest.mark.parametrize('input,output', [
+@pytest.mark.parametrize('path,rationalised_path', [
     ('', '/'),
     ('./', '/'),
     ('/', '/'),
@@ -29,8 +28,8 @@ from sherlockml.datasets import path
     ('./path/', '/path/'),
     ('/path/', '/path/')
 ])
-def test_rationalise_projectpath(input, output):
-    assert path.rationalise_projectpath(input) == output
+def test_rationalise_projectpath(path, rationalised_path):
+    assert path.rationalise_projectpath(path) == rationalised_path
 
 
 @pytest.mark.parametrize('project_path,project_id,bucket_path', [


### PR DESCRIPTION
This PR adds the datasets module from the previously unpublished `sherlockml.filesystem` module. 

Merging this PR will allow us to replace the legacy `sherlockml` library installed by default on SherlockML servers with this one and therefore safely release the new library to PyPI.

- Some refactoring was necessary to fit with the new library client patterns. I simplified some of the code while doing this refactoring.
- I took the opportunity to rename the subpackage to `datasets`, adding a `filesystem` module which proxies calls and displays a migration warning.
- Integration tests which actually copy objects to and from S3 remain in place - these should probably eventually be adapted to use `moto` instead.