### PR TITLE
Add single project retrieval method

### DIFF
--- a/sherlockml/clients/project.py
+++ b/sherlockml/clients/project.py
@@ -41,3 +41,7 @@ class ProjectClient(BaseClient):
     def list_accessible_by_user(self, user_id):
         endpoint = "/user/{}".format(user_id)
         return self._get(endpoint, ProjectSchema(many=True))
+
+    def get(self, project_id):
+        endpoint = "/project/{}".format(project_id)
+        return self._get(endpoint, ProjectSchema())

--- a/tests/clients/test_project.py
+++ b/tests/clients/test_project.py
@@ -54,3 +54,16 @@ def test_project_client_list_accessible_by_user(mocker):
     ProjectClient._get.assert_called_once_with(
         "/user/{}".format(USER_ID), schema_mock.return_value
     )
+
+
+def test_project_client_get(mocker):
+    mocker.patch.object(ProjectClient, "_get", return_value=PROJECT)
+    schema_mock = mocker.patch("sherlockml.clients.project.ProjectSchema")
+
+    client = ProjectClient(PROFILE)
+    assert client.get(PROJECT.id) == PROJECT
+
+    schema_mock.assert_called_once_with()
+    ProjectClient._get.assert_called_once_with(
+        "/project/{}".format(PROJECT.id), schema_mock.return_value
+    )


### PR DESCRIPTION
For when you need the name and / or owner id for a given project id.