### PR TITLE
Add a new client for users

### DIFF
--- a/sherlockml/clients/__init__.py
+++ b/sherlockml/clients/__init__.py
@@ -19,6 +19,7 @@ from sherlockml.clients.server import ServerClient
 from sherlockml.clients.cluster import ClusterClient
 from sherlockml.clients.secret import SecretClient
 from sherlockml.clients.workspace import WorkspaceClient
+from sherlockml.clients.user import UserClient
 
 
 CLIENT_FOR_RESOURCE = {
@@ -28,6 +29,7 @@ CLIENT_FOR_RESOURCE = {
     "cluster": ClusterClient,
     "secret": SecretClient,
     "workspace": WorkspaceClient,
+    "user": UserClient
 }
 
 

--- a/sherlockml/clients/__init__.py
+++ b/sherlockml/clients/__init__.py
@@ -29,7 +29,7 @@ CLIENT_FOR_RESOURCE = {
     "cluster": ClusterClient,
     "secret": SecretClient,
     "workspace": WorkspaceClient,
-    "user": UserClient
+    "user": UserClient,
 }
 
 

--- a/sherlockml/clients/__init__.py
+++ b/sherlockml/clients/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from sherlockml.clients.user import UserClient
+from sherlockml.clients.account import AccountClient
 from sherlockml.clients.project import ProjectClient
 from sherlockml.clients.server import ServerClient
 from sherlockml.clients.cluster import ClusterClient
@@ -22,7 +22,7 @@ from sherlockml.clients.workspace import WorkspaceClient
 
 
 CLIENT_FOR_RESOURCE = {
-    "user": UserClient,
+    "account": AccountClient,
     "project": ProjectClient,
     "server": ServerClient,
     "cluster": ClusterClient,

--- a/sherlockml/clients/account.py
+++ b/sherlockml/clients/account.py
@@ -48,4 +48,4 @@ class AccountClient(BaseClient):
 
     def authenticated_user_id(self):
         data = self._get("/authenticate", AuthenticationResponseSchema())
-        return data.user.id
+        return data.account.user_id

--- a/sherlockml/clients/account.py
+++ b/sherlockml/clients/account.py
@@ -24,7 +24,7 @@ Account = namedtuple("Account", ["user_id"])
 
 
 class AccountSchema(Schema):
-    id = fields.UUID(data_key="userId", required=True)
+    user_id = fields.UUID(data_key="userId", required=True)
 
     @post_load
     def make_user(self, data):

--- a/sherlockml/clients/account.py
+++ b/sherlockml/clients/account.py
@@ -31,7 +31,7 @@ class AccountSchema(Schema):
         return Account(**data)
 
 
-AuthenticationResponse = namedtuple("AuthenticationResponse", ["user"])
+AuthenticationResponse = namedtuple("AuthenticationResponse", ["account"])
 
 
 class AuthenticationResponseSchema(Schema):

--- a/sherlockml/clients/account.py
+++ b/sherlockml/clients/account.py
@@ -20,7 +20,7 @@ from marshmallow import Schema, fields, post_load
 from sherlockml.clients.base import BaseClient
 
 
-Account = namedtuple("User", ["id"])
+Account = namedtuple("Account", ["user_id"])
 
 
 class AccountSchema(Schema):

--- a/sherlockml/clients/account.py
+++ b/sherlockml/clients/account.py
@@ -27,7 +27,7 @@ class AccountSchema(Schema):
     user_id = fields.UUID(data_key="userId", required=True)
 
     @post_load
-    def make_user(self, data):
+    def make_account(self, data):
         return Account(**data)
 
 

--- a/sherlockml/clients/account.py
+++ b/sherlockml/clients/account.py
@@ -20,29 +20,29 @@ from marshmallow import Schema, fields, post_load
 from sherlockml.clients.base import BaseClient
 
 
-User = namedtuple("User", ["id"])
+Account = namedtuple("User", ["id"])
 
 
-class UserSchema(Schema):
+class AccountSchema(Schema):
     id = fields.UUID(data_key="userId", required=True)
 
     @post_load
     def make_user(self, data):
-        return User(**data)
+        return Account(**data)
 
 
 AuthenticationResponse = namedtuple("AuthenticationResponse", ["user"])
 
 
 class AuthenticationResponseSchema(Schema):
-    user = fields.Nested(UserSchema, data_key="account", required=True)
+    user = fields.Nested(AccountSchema, data_key="account", required=True)
 
     @post_load
     def make_authentication_response(self, data):
         return AuthenticationResponse(**data)
 
 
-class UserClient(BaseClient):
+class AccountClient(BaseClient):
 
     SERVICE_NAME = "hudson"
 

--- a/sherlockml/clients/account.py
+++ b/sherlockml/clients/account.py
@@ -35,7 +35,7 @@ AuthenticationResponse = namedtuple("AuthenticationResponse", ["account"])
 
 
 class AuthenticationResponseSchema(Schema):
-    user = fields.Nested(AccountSchema, data_key="account", required=True)
+    account = fields.Nested(AccountSchema, required=True)
 
     @post_load
     def make_authentication_response(self, data):

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -50,8 +50,10 @@ class UserSchema(Schema):
     email = fields.Str(required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     enabled = fields.Boolean(required=True)
-    global_roles = EnumField(
-        GlobalRole, by_value=True, many=True, required=True
+    global_roles = fields.List(
+        EnumField(GlobalRole, by_value=True),
+        data_key="globalRoles",
+        required=True,
     )
 
     @post_load

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -37,7 +37,7 @@ User = namedtuple(
         "email",
         "created_at",
         "enabled",
-        "global_roles"
+        "global_roles",
     ],
 )
 
@@ -50,7 +50,11 @@ class UserSchema(Schema):
     email = fields.Str(required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     enabled = fields.Boolean(required=True)
-    global_roles = fields.List(EnumField(GlobalRole, by_value=True), data_key="globalRoles", required=True)
+    global_roles = fields.List(
+        EnumField(GlobalRole, by_value=True),
+        data_key="globalRoles",
+        required=True,
+    )
 
     @post_load
     def make_project(self, data):

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -14,10 +14,18 @@
 
 
 from collections import namedtuple
+from enum import Enum
 
 from marshmallow import Schema, fields, post_load
+from marshmallow_enum import EnumField
 
 from sherlockml.clients.base import BaseClient
+
+
+class GlobalRole(Enum):
+    BASIC_USER = "global-basic-user"
+    FULL_USER = "global-full-user"
+    ADMIN = "global-admin"
 
 
 User = namedtuple(
@@ -29,7 +37,6 @@ User = namedtuple(
         "email",
         "created_at",
         "enabled",
-        "attributes",
         "global_roles"
     ],
 )
@@ -43,8 +50,7 @@ class UserSchema(Schema):
     email = fields.Str(required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     enabled = fields.Boolean(required=True)
-    attributes = fields.Dict(required=True)
-    global_roles = fields.List(fields.Str(), data_key="globalRoles", required=True)
+    global_roles = fields.List(EnumField(GlobalRole, by_value=True), data_key="globalRoles", required=True)
 
     @post_load
     def make_project(self, data):

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -70,7 +70,7 @@ class UserClient(BaseClient):
         response = self._get(endpoint, UserSchema())
         return response
 
-    def get_users(self):
+    def get_all_users(self):
         endpoint = "/users"
         response = self._get(endpoint, UserSchema(many=True))
         return response

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -50,10 +50,8 @@ class UserSchema(Schema):
     email = fields.Str(required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     enabled = fields.Boolean(required=True)
-    global_roles = fields.List(
-        EnumField(GlobalRole, by_value=True),
-        data_key="globalRoles",
-        required=True,
+    global_roles = EnumField(
+        GlobalRole, by_value=True, many=True, required=True
     )
 
     @post_load

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -1,0 +1,73 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections import namedtuple
+
+from marshmallow import Schema, fields, post_load
+
+from sherlockml.clients.base import BaseClient
+
+
+User = namedtuple(
+    "User",
+    [
+        "id",
+        "username",
+        "full_name",
+        "email",
+        "created_at",
+        "enabled",
+        "attributes",
+        "global_roles"
+    ],
+)
+
+
+class UserSchema(Schema):
+
+    id = fields.UUID(data_key="userId", required=True)
+    username = fields.Str(required=True)
+    full_name = fields.Str(data_key="fullName", required=True)
+    email = fields.Str(required=True)
+    created_at = fields.DateTime(data_key="createdAt", required=True)
+    enabled = fields.Boolean(required=True)
+    attributes = fields.Dict(required=True)
+    global_roles = fields.List(fields.Str(), data_key="globalRoles", required=True)
+
+    @post_load
+    def make_project(self, data):
+        return User(**data)
+
+
+class UserClient(BaseClient):
+
+    SERVICE_NAME = "flock"
+
+    def get_user(self, user_id):
+        endpoint = "/user/{}".format(user_id)
+        response = self._get(endpoint, UserSchema())
+        return response
+
+    def get_users(self):
+        endpoint = "/users"
+        response = self._get(endpoint, UserSchema(many=True))
+        return response
+
+    def set_global_roles(self, user_id, global_roles):
+        endpoint = "/user/{}/roles".format(user_id)
+        response = self._put(
+            endpoint, UserSchema(), json={"roles": global_roles}
+        )
+        return response

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -57,7 +57,7 @@ class UserSchema(Schema):
     )
 
     @post_load
-    def make_project(self, data):
+    def make_user(self, data):
         return User(**data)
 
 

--- a/tests/clients/test_account.py
+++ b/tests/clients/test_account.py
@@ -17,10 +17,10 @@ import uuid
 import pytest
 from marshmallow import ValidationError
 
-from sherlockml.clients.user import (
-    UserClient,
-    User,
-    UserSchema,
+from sherlockml.clients.account import (
+    AccountClient,
+    Account,
+    AccountSchema,
     AuthenticationResponse,
     AuthenticationResponseSchema,
 )
@@ -30,24 +30,24 @@ from tests.clients.fixtures import PROFILE
 USER_ID = uuid.uuid4()
 
 
-def test_user_schema():
-    data = UserSchema().load({"userId": str(USER_ID)})
-    assert data == User(id=USER_ID)
+def test_account_schema():
+    data = AccountSchema().load({"userId": str(USER_ID)})
+    assert data == Account(id=USER_ID)
 
 
 @pytest.mark.parametrize(
     "data", [{}, {"id": str(USER_ID)}, {"userId": "not-a-uuid"}]
 )
-def test_user_schema_invalid(data):
+def test_account_schema_invalid(data):
     with pytest.raises(ValidationError):
-        UserSchema().load(data)
+        AccountSchema().load(data)
 
 
 def test_authentication_response_schema():
     data = AuthenticationResponseSchema().load(
         {"account": {"userId": str(USER_ID)}}
     )
-    assert data == AuthenticationResponse(user=User(id=USER_ID))
+    assert data == AuthenticationResponse(user=Account(id=USER_ID))
 
 
 @pytest.mark.parametrize(
@@ -58,21 +58,21 @@ def test_authentication_response_schema_invalid(data):
         AuthenticationResponseSchema().load(data)
 
 
-def test_user_client_authenticated_user_id(mocker):
+def test_account_client_authenticated_user_id(mocker):
     mocker.patch.object(
-        UserClient,
+        AccountClient,
         "_get",
-        return_value=AuthenticationResponse(user=User(id=USER_ID)),
+        return_value=AuthenticationResponse(user=Account(id=USER_ID)),
     )
 
     schema_mock = mocker.patch(
-        "sherlockml.clients.user.AuthenticationResponseSchema"
+        "sherlockml.clients.account.AuthenticationResponseSchema"
     )
 
-    client = UserClient(PROFILE)
+    client = AccountClient(PROFILE)
 
     assert client.authenticated_user_id() == USER_ID
 
-    UserClient._get.assert_called_once_with(
+    AccountClient._get.assert_called_once_with(
         "/authenticate", schema_mock.return_value
     )

--- a/tests/clients/test_account.py
+++ b/tests/clients/test_account.py
@@ -32,7 +32,7 @@ USER_ID = uuid.uuid4()
 
 def test_account_schema():
     data = AccountSchema().load({"userId": str(USER_ID)})
-    assert data == Account(id=USER_ID)
+    assert data == Account(user_id=USER_ID)
 
 
 @pytest.mark.parametrize(
@@ -47,11 +47,13 @@ def test_authentication_response_schema():
     data = AuthenticationResponseSchema().load(
         {"account": {"userId": str(USER_ID)}}
     )
-    assert data == AuthenticationResponse(user=Account(id=USER_ID))
+    assert data == AuthenticationResponse(account=Account(user_id=USER_ID))
 
 
 @pytest.mark.parametrize(
-    "data", [{}, {"user": {"id": str(USER_ID)}}, {"account": "not-an-account"}]
+    "data", [
+        {}, {"account": {"id": str(USER_ID)}}, {"account": "not-an-account"}
+    ]
 )
 def test_authentication_response_schema_invalid(data):
     with pytest.raises(ValidationError):
@@ -62,7 +64,7 @@ def test_account_client_authenticated_user_id(mocker):
     mocker.patch.object(
         AccountClient,
         "_get",
-        return_value=AuthenticationResponse(user=Account(id=USER_ID)),
+        return_value=AuthenticationResponse(account=Account(user_id=USER_ID)),
     )
 
     schema_mock = mocker.patch(

--- a/tests/clients/test_account.py
+++ b/tests/clients/test_account.py
@@ -51,9 +51,8 @@ def test_authentication_response_schema():
 
 
 @pytest.mark.parametrize(
-    "data", [
-        {}, {"account": {"id": str(USER_ID)}}, {"account": "not-an-account"}
-    ]
+    "data",
+    [{}, {"account": {"id": str(USER_ID)}}, {"account": "not-an-account"}],
 )
 def test_authentication_response_schema_invalid(data):
     with pytest.raises(ValidationError):

--- a/tests/clients/test_init.py
+++ b/tests/clients/test_init.py
@@ -16,11 +16,11 @@
 import pytest
 
 import sherlockml.clients
-from sherlockml.clients.user import UserClient
+from sherlockml.clients.account import AccountClient
 
 
 def test_for_resource():
-    assert sherlockml.clients.for_resource("user") is UserClient
+    assert sherlockml.clients.for_resource("account") is AccountClient
 
 
 def test_for_resource_missing():

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -26,16 +26,15 @@ USER_ID = uuid.uuid4()
 CREATED_AT = datetime(2018, 3, 10, 11, 32, 6, 247000, tzinfo=UTC)
 CREATED_AT_STRING = "2018-03-10T11:32:06.247Z"
 
-TEST_USER_JSON = dict(
-    userId=str(USER_ID),
-    username="test-user",
-    fullName="Test User",
-    email="test@email.com",
-    createdAt=CREATED_AT_STRING,
-    enabled="true",
-    globalRoles=["global-basic-user", "global-full-user"],
-)
-
+TEST_USER_JSON = {
+    "userId": str(USER_ID),
+    "username": "test-user",
+    "fullName": "Test User",
+    "email": "test@email.com",
+    "createdAt": CREATED_AT_STRING,
+    "enabled": "true",
+    "globalRoles": ["global-basic-user", "global-full-user"],
+}
 
 EXPECTED_USER = User(
     id=USER_ID,

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -52,12 +52,12 @@ def test_user_schema():
     assert data == EXPECTED_USER
 
 
-def test_user_schema_invalid(data):
+def test_user_schema_invalid():
     with pytest.raises(ValidationError):
         UserSchema().load({})
 
 
-def test_user_schema_invalid_uuid(data):
+def test_user_schema_invalid_uuid():
     body = TEST_USER_JSON.copy()
     body["userId"] = "not-a-uuid"
     with pytest.raises(ValidationError):

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -52,12 +52,16 @@ def test_user_schema():
     assert data == EXPECTED_USER
 
 
-@pytest.mark.parametrize(
-    "data", [{}, {**TEST_USER_JSON, "userId": "not-a-uuid"}]
-)
 def test_user_schema_invalid(data):
     with pytest.raises(ValidationError):
-        UserSchema().load(data)
+        UserSchema().load({})
+
+
+def test_user_schema_invalid_uuid(data):
+    body = TEST_USER_JSON.copy()
+    body["userId"] = "not-a-uuid"
+    with pytest.raises(ValidationError):
+        UserSchema().load(body)
 
 
 def test_user_schema_missing_userId():

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -49,3 +49,25 @@ EXPECTED_USER = User(
 def test_user_schema():
     data = UserSchema().load(TEST_USER_JSON)
     assert data == EXPECTED_USER
+
+
+@pytest.mark.parametrize(
+    "data", [{}, {**TEST_USER_JSON, "userId": "not-a-uuid"}]
+)
+def test_user_schema_invalid(data):
+    with pytest.raises(ValidationError):
+        UserSchema().load(data)
+
+
+def test_user_schema_missing_userId():
+    body = TEST_USER_JSON.copy()
+    body.pop("userId")
+    with pytest.raises(ValidationError):
+        UserSchema().load(body)
+
+
+def test_user_schema_invalid_global_role():
+    body = TEST_USER_JSON.copy()
+    body["globalRoles"] = ["invalid-global-role"]
+    with pytest.raises(ValidationError):
+        UserSchema().load(body)

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -94,13 +94,13 @@ def test_get_user(mocker):
     )
 
 
-def test_get_users(mocker):
+def test_get_all_users(mocker):
     mocker.patch.object(UserClient, "_get", return_value=[EXPECTED_USER])
     schema_mock = mocker.patch("sherlockml.clients.user.UserSchema")
 
     client = UserClient(PROFILE)
 
-    users = client.get_users()
+    users = client.get_all_users()
 
     assert users == [EXPECTED_USER]
 

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import uuid
 from datetime import datetime
 
 import pytest
-from marshmallow import ValidationError
 from dateutil.tz import UTC
+from marshmallow import ValidationError
 
 from sherlockml.clients.user import UserClient, User, UserSchema, GlobalRole
 from tests.clients.fixtures import PROFILE

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -1,0 +1,55 @@
+# Copyright 2018 ASI Data Science
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import uuid
+from datetime import datetime
+
+import pytest
+from marshmallow import ValidationError
+from dateutil.tz import UTC
+
+from sherlockml.clients.user import (
+    UserClient, User, UserSchema, GlobalRole
+)
+
+USER_ID = uuid.uuid4()
+CREATED_AT = datetime(2018, 3, 10, 11, 32, 6, 247000, tzinfo=UTC)
+CREATED_AT_STRING = "2018-03-10T11:32:06.247Z"
+
+TEST_USER_JSON = dict(
+    userId=str(USER_ID),
+    username='test-user',
+    fullName='Test User',
+    email='test@email.com',
+    createdAt=CREATED_AT_STRING,
+    enabled='true',
+    globalRoles=['global-basic-user', 'global-full-user']
+)
+
+
+EXPECTED_USER = User(
+    id=USER_ID,
+    username='test-user',
+    full_name='Test User',
+    email='test@email.com',
+    created_at=CREATED_AT,
+    enabled=True,
+    global_roles=[GlobalRole.BASIC_USER, GlobalRole.FULL_USER]
+)
+
+
+def test_user_schema():
+    data = UserSchema().load(TEST_USER_JSON)
+    assert data == EXPECTED_USER
+
+

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -18,9 +18,7 @@ import pytest
 from marshmallow import ValidationError
 from dateutil.tz import UTC
 
-from sherlockml.clients.user import (
-    UserClient, User, UserSchema, GlobalRole
-)
+from sherlockml.clients.user import UserClient, User, UserSchema, GlobalRole
 
 USER_ID = uuid.uuid4()
 CREATED_AT = datetime(2018, 3, 10, 11, 32, 6, 247000, tzinfo=UTC)
@@ -28,28 +26,26 @@ CREATED_AT_STRING = "2018-03-10T11:32:06.247Z"
 
 TEST_USER_JSON = dict(
     userId=str(USER_ID),
-    username='test-user',
-    fullName='Test User',
-    email='test@email.com',
+    username="test-user",
+    fullName="Test User",
+    email="test@email.com",
     createdAt=CREATED_AT_STRING,
-    enabled='true',
-    globalRoles=['global-basic-user', 'global-full-user']
+    enabled="true",
+    globalRoles=["global-basic-user", "global-full-user"],
 )
 
 
 EXPECTED_USER = User(
     id=USER_ID,
-    username='test-user',
-    full_name='Test User',
-    email='test@email.com',
+    username="test-user",
+    full_name="Test User",
+    email="test@email.com",
     created_at=CREATED_AT,
     enabled=True,
-    global_roles=[GlobalRole.BASIC_USER, GlobalRole.FULL_USER]
+    global_roles=[GlobalRole.BASIC_USER, GlobalRole.FULL_USER],
 )
 
 
 def test_user_schema():
     data = UserSchema().load(TEST_USER_JSON)
     assert data == EXPECTED_USER
-
-


### PR DESCRIPTION
Create a new 'user' client. 

The client formerlly called 'user' has been renamed 'account'. We should check this isn't a breaking change before merging. 