### PR TITLE
Remove `sudo: true` from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,4 @@ jobs:
         - flake8
         - python setup.py test
       dist: xenial
-      sudo: true
       python: "3.7"


### PR DESCRIPTION
This is no longer necessary due to [recent Travis CI infrastructure updates](https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-is-here!-79690).