### PR TITLE
Fix: allow deserializing users when there are system users

### DIFF
--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -74,7 +74,7 @@ class UserClient(BaseClient):
 
     def get_all_users(self):
         endpoint = "/users"
-        response = self._get(endpoint, UserSchema(many=True))
+        response = self._get(endpoint, UserSchema(many=True), params={})
         return response
 
     def set_global_roles(self, user_id, global_roles):

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -72,9 +72,12 @@ class UserClient(BaseClient):
         response = self._get(endpoint, UserSchema())
         return response
 
-    def get_all_users(self):
+    def get_all_users(self, is_system=None):
+        params = {}
+        if is_system is not None:
+            params["isSystem"] = "true" if is_system else "false"
         endpoint = "/users"
-        response = self._get(endpoint, UserSchema(many=True), params={})
+        response = self._get(endpoint, UserSchema(many=True), params=params)
         return response
 
     def set_global_roles(self, user_id, global_roles):

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -38,6 +38,7 @@ User = namedtuple(
         "created_at",
         "enabled",
         "global_roles",
+        "is_system",
     ],
 )
 
@@ -55,6 +56,7 @@ class UserSchema(Schema):
         data_key="globalRoles",
         missing=None,
     )
+    is_system = fields.Boolean(data_key="isSystem", required=True)
 
     @post_load
     def make_user(self, data):

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -72,10 +72,12 @@ class UserClient(BaseClient):
         response = self._get(endpoint, UserSchema())
         return response
 
-    def get_all_users(self, is_system=None):
+    def get_all_users(self, is_system=None, enabled=None):
         params = {}
         if is_system is not None:
             params["isSystem"] = "true" if is_system else "false"
+        if enabled is not None:
+            params["isDisabled"] = "false" if enabled else "true"
         endpoint = "/users"
         response = self._get(endpoint, UserSchema(many=True), params=params)
         return response

--- a/sherlockml/clients/user.py
+++ b/sherlockml/clients/user.py
@@ -46,14 +46,14 @@ class UserSchema(Schema):
 
     id = fields.UUID(data_key="userId", required=True)
     username = fields.Str(required=True)
-    full_name = fields.Str(data_key="fullName", required=True)
+    full_name = fields.Str(data_key="fullName", missing=None)
     email = fields.Str(required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     enabled = fields.Boolean(required=True)
     global_roles = fields.List(
         EnumField(GlobalRole, by_value=True),
         data_key="globalRoles",
-        required=True,
+        missing=None,
     )
 
     @post_load

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -135,6 +135,15 @@ def test_get_user(mocker):
         (True, False, {"isSystem": "true", "isDisabled": "true"}),
         (False, False, {"isSystem": "false", "isDisabled": "true"}),
     ],
+    ids=[
+        "basic",
+        "system only",
+        "human only",
+        "enabled only",
+        "disabled only",
+        "system and disabled only",
+        "human and disabled only",
+    ],
 )
 def test_get_all_users(mocker, is_system, enabled, expected_params):
     mocker.patch.object(UserClient, "_get", return_value=[EXPECTED_HUMAN_USER])

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -125,7 +125,12 @@ def test_get_user(mocker):
 
 
 @pytest.mark.parametrize(
-    "is_system, enabled, expected_params", [(None, None, {})]
+    "is_system, enabled, expected_params",
+    [
+        (None, None, {}),
+        (True, None, {"isSystem": "true"}),
+        (False, None, {"isSystem": "false"}),
+    ],
 )
 def test_get_all_users(mocker, is_system, enabled, expected_params):
     mocker.patch.object(UserClient, "_get", return_value=[EXPECTED_HUMAN_USER])
@@ -133,7 +138,7 @@ def test_get_all_users(mocker, is_system, enabled, expected_params):
 
     client = UserClient(PROFILE)
 
-    users = client.get_all_users()
+    users = client.get_all_users(is_system=is_system)
 
     assert users == [EXPECTED_HUMAN_USER]
 

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -47,10 +47,37 @@ EXPECTED_HUMAN_USER = User(
     global_roles=[GlobalRole.BASIC_USER, GlobalRole.FULL_USER],
 )
 
+TEST_SYSTEM_USER_JSON = {
+    "userId": str(USER_ID),
+    "username": "test-user",
+    "email": "invalid-email",
+    "createdAt": CREATED_AT_STRING,
+    "enabled": True,
+    "isSystem": True,
+}
 
-def test_user_schema():
-    data = UserSchema().load(TEST_HUMAN_USER_JSON)
-    assert data == EXPECTED_HUMAN_USER
+EXPECTED_SYSTEM_USER = User(
+    id=USER_ID,
+    username="test-user",
+    full_name=None,
+    email="invalid-email",
+    created_at=CREATED_AT,
+    enabled=True,
+    global_roles=None,
+)
+
+
+@pytest.mark.parametrize(
+    "body, expected_user",
+    [
+        (TEST_HUMAN_USER_JSON, EXPECTED_HUMAN_USER),
+        (TEST_SYSTEM_USER_JSON, EXPECTED_SYSTEM_USER),
+    ],
+    ids=["human", "system"],
+)
+def test_user_schema(body, expected_user):
+    data = UserSchema().load(body)
+    assert data == expected_user
 
 
 def test_user_schema_invalid():

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -45,6 +45,7 @@ EXPECTED_HUMAN_USER = User(
     created_at=CREATED_AT,
     enabled=True,
     global_roles=[GlobalRole.BASIC_USER, GlobalRole.FULL_USER],
+    is_system=False,
 )
 
 TEST_SYSTEM_USER_JSON = {
@@ -64,6 +65,7 @@ EXPECTED_SYSTEM_USER = User(
     created_at=CREATED_AT,
     enabled=True,
     global_roles=None,
+    is_system=True,
 )
 
 

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -130,6 +130,8 @@ def test_get_user(mocker):
         (None, None, {}),
         (True, None, {"isSystem": "true"}),
         (False, None, {"isSystem": "false"}),
+        (None, True, {"isDisabled": "false"}),
+        (None, False, {"isDisabled": "true"}),
     ],
 )
 def test_get_all_users(mocker, is_system, enabled, expected_params):
@@ -138,7 +140,7 @@ def test_get_all_users(mocker, is_system, enabled, expected_params):
 
     client = UserClient(PROFILE)
 
-    users = client.get_all_users(is_system=is_system)
+    users = client.get_all_users(is_system=is_system, enabled=enabled)
 
     assert users == [EXPECTED_HUMAN_USER]
 

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -132,6 +132,8 @@ def test_get_user(mocker):
         (False, None, {"isSystem": "false"}),
         (None, True, {"isDisabled": "false"}),
         (None, False, {"isDisabled": "true"}),
+        (True, False, {"isSystem": "true", "isDisabled": "true"}),
+        (False, False, {"isSystem": "false", "isDisabled": "true"}),
     ],
 )
 def test_get_all_users(mocker, is_system, enabled, expected_params):

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -26,17 +26,18 @@ USER_ID = uuid.uuid4()
 CREATED_AT = datetime(2018, 3, 10, 11, 32, 6, 247000, tzinfo=UTC)
 CREATED_AT_STRING = "2018-03-10T11:32:06.247Z"
 
-TEST_USER_JSON = {
+TEST_HUMAN_USER_JSON = {
     "userId": str(USER_ID),
     "username": "test-user",
     "fullName": "Test User",
     "email": "test@email.com",
     "createdAt": CREATED_AT_STRING,
-    "enabled": "true",
+    "enabled": True,
+    "isSystem": False,
     "globalRoles": ["global-basic-user", "global-full-user"],
 }
 
-EXPECTED_USER = User(
+EXPECTED_HUMAN_USER = User(
     id=USER_ID,
     username="test-user",
     full_name="Test User",
@@ -48,8 +49,8 @@ EXPECTED_USER = User(
 
 
 def test_user_schema():
-    data = UserSchema().load(TEST_USER_JSON)
-    assert data == EXPECTED_USER
+    data = UserSchema().load(TEST_HUMAN_USER_JSON)
+    assert data == EXPECTED_HUMAN_USER
 
 
 def test_user_schema_invalid():
@@ -58,35 +59,35 @@ def test_user_schema_invalid():
 
 
 def test_user_schema_invalid_uuid():
-    body = TEST_USER_JSON.copy()
+    body = TEST_HUMAN_USER_JSON.copy()
     body["userId"] = "not-a-uuid"
     with pytest.raises(ValidationError):
         UserSchema().load(body)
 
 
 def test_user_schema_missing_userId():
-    body = TEST_USER_JSON.copy()
+    body = TEST_HUMAN_USER_JSON.copy()
     body.pop("userId")
     with pytest.raises(ValidationError):
         UserSchema().load(body)
 
 
 def test_user_schema_invalid_global_role():
-    body = TEST_USER_JSON.copy()
+    body = TEST_HUMAN_USER_JSON.copy()
     body["globalRoles"] = ["invalid-global-role"]
     with pytest.raises(ValidationError):
         UserSchema().load(body)
 
 
 def test_get_user(mocker):
-    mocker.patch.object(UserClient, "_get", return_value=EXPECTED_USER)
+    mocker.patch.object(UserClient, "_get", return_value=EXPECTED_HUMAN_USER)
     schema_mock = mocker.patch("sherlockml.clients.user.UserSchema")
 
     client = UserClient(PROFILE)
 
     user = client.get_user(str(USER_ID))
 
-    assert user == EXPECTED_USER
+    assert user == EXPECTED_HUMAN_USER
 
     schema_mock.assert_called_once_with()
     UserClient._get.assert_called_once_with(
@@ -95,14 +96,14 @@ def test_get_user(mocker):
 
 
 def test_get_all_users(mocker):
-    mocker.patch.object(UserClient, "_get", return_value=[EXPECTED_USER])
+    mocker.patch.object(UserClient, "_get", return_value=[EXPECTED_HUMAN_USER])
     schema_mock = mocker.patch("sherlockml.clients.user.UserSchema")
 
     client = UserClient(PROFILE)
 
     users = client.get_all_users()
 
-    assert users == [EXPECTED_USER]
+    assert users == [EXPECTED_HUMAN_USER]
 
     schema_mock.assert_called_once_with(many=True)
     UserClient._get.assert_called_once_with("/users", schema_mock.return_value)

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -124,7 +124,10 @@ def test_get_user(mocker):
     )
 
 
-def test_get_all_users(mocker):
+@pytest.mark.parametrize(
+    "is_system, enabled, expected_params", [(None, None, {})]
+)
+def test_get_all_users(mocker, is_system, enabled, expected_params):
     mocker.patch.object(UserClient, "_get", return_value=[EXPECTED_HUMAN_USER])
     schema_mock = mocker.patch("sherlockml.clients.user.UserSchema")
 
@@ -135,7 +138,9 @@ def test_get_all_users(mocker):
     assert users == [EXPECTED_HUMAN_USER]
 
     schema_mock.assert_called_once_with(many=True)
-    UserClient._get.assert_called_once_with("/users", schema_mock.return_value)
+    UserClient._get.assert_called_once_with(
+        "/users", schema_mock.return_value, params=expected_params
+    )
 
 
 def test_set_global_roles(mocker):


### PR DESCRIPTION
Prior to this PR, fetching all users failed when there were system users. This fixes it and adds the ability to specify whether to select only system or only human users.

I tested this extensively by taking the admin credentials from the fantomas bastion.